### PR TITLE
Use a json file instead of an ini one to store settings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "vcpkg"]
 	path = ci/vcpkg
 	url = https://github.com/microsoft/vcpkg/
-[submodule "thirdparty/simpleini"]
-	path = thirdparty/simpleini
-	url = https://github.com/brofield/simpleini
 [submodule "thirdparty/IXWebSocket"]
 	path = thirdparty/IXWebSocket
 	url = https://github.com/machinezone/ixwebsocket

--- a/abaddon.cpp
+++ b/abaddon.cpp
@@ -371,8 +371,7 @@ void Abaddon::SaveState() {
     state.ActiveChannel = m_main_window->GetChatActiveChannel();
     state.Expansion = m_main_window->GetChannelList()->GetExpansionState();
 
-    const auto path = GetStateCachePath();
-    if (!util::IsFolder(path)) {
+    if (const auto path = GetStateCachePath(); !util::IsFolder(path)) {
         std::error_code ec;
         std::filesystem::create_directories(path, ec);
     }
@@ -446,18 +445,15 @@ void Abaddon::on_user_menu_remove_recipient() {
 }
 
 std::string Abaddon::GetCSSPath() {
-    const static auto path = Platform::FindResourceFolder() + "/css";
-    return path;
+    return Platform::FindResourceFolder() + "/css";
 }
 
 std::string Abaddon::GetResPath() {
-    const static auto path = Platform::FindResourceFolder() + "/res";
-    return path;
+    return Platform::FindResourceFolder() + "/res";
 }
 
 std::string Abaddon::GetStateCachePath() {
-    const static auto path = Platform::FindStateCacheFolder() + "/state";
-    return path;
+    return Platform::FindStateCacheFolder() + "/state";
 }
 
 std::string Abaddon::GetCSSPath(const std::string &path) {

--- a/platform.cpp
+++ b/platform.cpp
@@ -83,27 +83,16 @@ std::string Platform::FindStateCacheFolder() {
 
 #elif defined(__linux__)
 std::string Platform::FindResourceFolder() {
-    static std::string found_path;
-    static bool found = false;
-    if (found) return found_path;
-
-    const auto home_env = std::getenv("HOME");
-    if (home_env != nullptr) {
-        const static std::string home_path = home_env + "/.local/share/abaddon"s;
-
+    if (const auto home_env = std::getenv("HOME"); home_env != nullptr) {
+        auto home_path = std::string(home_env) + "/.local/share/abaddon";
         for (const auto &path : { "."s, home_path, std::string(ABADDON_DEFAULT_RESOURCE_DIR) }) {
             if (util::IsFolder(path + "/res") && util::IsFolder(path + "/css")) {
-                found_path = path;
-                found = true;
-                return found_path;
+                return path;
             }
         }
     }
-
     puts("cant find a resources folder, will try to load from cwd");
-    found_path = ".";
-    found = true;
-    return found_path;
+    return ".";
 }
 
 std::string Platform::FindConfigFile() {
@@ -111,10 +100,9 @@ std::string Platform::FindConfigFile() {
     if (x != nullptr)
         return x;
 
-    const auto home_env = std::getenv("HOME");
-    if (home_env != nullptr) {
-        const auto home_path = home_env + "/.config/abaddon/abaddon.ini"s;
-        for (auto path : { "./abaddon.ini"s, home_path }) {
+    if (const auto home_env = std::getenv("HOME"); home_env != nullptr) {
+        const auto home_path = std::string(home_env) + "/.config/abaddon/abaddon.ini";
+        for (const auto &path : { "./abaddon.ini"s, home_path }) {
             if (util::IsFile(path)) return path;
         }
     }
@@ -123,9 +111,8 @@ std::string Platform::FindConfigFile() {
 }
 
 std::string Platform::FindStateCacheFolder() {
-    const auto home_env = std::getenv("HOME");
-    if (home_env != nullptr) {
-        auto home_path = home_env + "/.cache/abaddon"s;
+    if (const auto home_env = std::getenv("HOME"); home_env != nullptr) {
+        auto home_path = std::string(home_env) + "/.cache/abaddon";
         std::error_code ec;
         if (!util::IsFolder(home_path))
             std::filesystem::create_directories(home_path, ec);

--- a/platform.cpp
+++ b/platform.cpp
@@ -7,6 +7,8 @@
 
 using namespace std::literals::string_literals;
 
+constexpr auto CONFIG_FILENAME = std::string_view { "abaddon.json" };
+
 #if defined(_WIN32) && defined(_MSC_VER)
     #include <Windows.h>
     #include <Shlwapi.h>
@@ -71,10 +73,9 @@ std::string Platform::FindResourceFolder() {
 }
 
 std::string Platform::FindConfigFile() {
-    const auto x = std::getenv("ABADDON_CONFIG");
-    if (x != nullptr)
+    if (const auto x = std::getenv("ABADDON_CONFIG"); x != nullptr)
         return x;
-    return "./abaddon.ini";
+    return std::string { CONFIG_FILENAME };
 }
 
 std::string Platform::FindStateCacheFolder() {
@@ -96,18 +97,17 @@ std::string Platform::FindResourceFolder() {
 }
 
 std::string Platform::FindConfigFile() {
-    const auto x = std::getenv("ABADDON_CONFIG");
-    if (x != nullptr)
+    if (const auto x = std::getenv("ABADDON_CONFIG"); x != nullptr)
         return x;
-
     if (const auto home_env = std::getenv("HOME"); home_env != nullptr) {
-        const auto home_path = std::string(home_env) + "/.config/abaddon/abaddon.ini";
-        for (const auto &path : { "./abaddon.ini"s, home_path }) {
-            if (util::IsFile(path)) return path;
+        auto home_path = std::string(home_env) + "/.config/abaddon/";
+        home_path += CONFIG_FILENAME;
+        for (const auto path : { CONFIG_FILENAME, std::string_view { home_path } }) {
+            if (util::IsFile(path)) return std::string { path };
         }
     }
     puts("can't find configuration file!");
-    return "./abaddon.ini";
+    return std::string { CONFIG_FILENAME };
 }
 
 std::string Platform::FindStateCacheFolder() {
@@ -130,11 +130,10 @@ std::string Platform::FindResourceFolder() {
 }
 
 std::string Platform::FindConfigFile() {
-    const auto x = std::getenv("ABADDON_CONFIG");
-    if (x != nullptr)
+    if (const auto x = std::getenv("ABADDON_CONFIG"); x != nullptr)
         return x;
     puts("unknown OS, trying to load config from cwd");
-    return "./abaddon.ini";
+    return std::string { CONFIG_FILENAME };
 }
 
 std::string Platform::FindStateCacheFolder() {

--- a/platform.hpp
+++ b/platform.hpp
@@ -6,4 +6,4 @@ bool SetupFonts();
 std::string FindResourceFolder();
 std::string FindConfigFile();
 std::string FindStateCacheFolder();
-}
+} // namespace Platform


### PR DESCRIPTION
removes SimpleIni as dependency, plus we get all the other benefits of json.

This PR also includes a change to remove static usage in the linux part of platform.cpp