### PR TITLE
Remove zipped resource archive in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,3 +356,9 @@ build/
 out/
 
 fonts/fonts.conf
+
+# To make sure no zipped resources are added to the repo
+*.7z
+*.zip
+*.tar.*
+*.rar


### PR DESCRIPTION
I guess someone added the zipped archive by accident, so this PR removes it an adds appropriate gitignore entries to prevent this from happening again.