### PR TITLE
Fix: do not grow message input text box horizontally when typing (fix text wrapping)

### DIFF
--- a/src/components/chatinput.cpp
+++ b/src/components/chatinput.cpp
@@ -5,7 +5,7 @@ ChatInput::ChatInput() {
     set_propagate_natural_height(true);
     set_min_content_height(20);
     set_max_content_height(250);
-    set_policy(Gtk::POLICY_NEVER, Gtk::POLICY_AUTOMATIC);
+    set_policy(Gtk::POLICY_EXTERNAL, Gtk::POLICY_AUTOMATIC);
 
     // hack
     auto cb = [this](GdkEventKey *e) -> bool {


### PR DESCRIPTION
I have been encountering a problem where the text input box would grow horizontally and push some of the text off the left side of the screen, with no way to scroll back to it. Setting the parent scrollarea's scroll policy property to `GTK_POLICY_EXTERNAL` seems to fix things.

I have only tested this on my Debian Sid machine running FVWM and using a CDE-derived GTK theme. If it doesn't break things on your systems, please consider merging it.

https://docs.gtk.org/gtk3/enum.PolicyType.html

In the previous `GTK_POLICY_NEVER` policy, "the content determines the size," which means things grow and push underneath other things. It seems pretty idiosyncratic. I could sometimes get things to wrap by pasting them in, but if I manually typed them the box would just grow.

As far as i can tell, things 100% work now.