### PR TITLE
Fix for text wrapping in chat input - attachment branch edition

### DIFF
--- a/src/components/chatinput.cpp
+++ b/src/components/chatinput.cpp
@@ -8,7 +8,7 @@ ChatInputText::ChatInputText() {
     set_propagate_natural_height(true);
     set_min_content_height(20);
     set_max_content_height(250);
-    set_policy(Gtk::POLICY_NEVER, Gtk::POLICY_AUTOMATIC);
+    set_policy(Gtk::POLICY_EXTERNAL, Gtk::POLICY_AUTOMATIC);
 
     // hack
     auto cb = [this](GdkEventKey *e) -> bool {


### PR DESCRIPTION
Attachment branch had the same text wrapping problem previously fixed in main branch with https://github.com/uowuo/abaddon/pull/89.

Might want to just merge the other PR, but I figured I'd open a PR here, too.

(side note: I did not figure out how to "browse" for a file. Do I ***have*** to use an external file manager and drag, then? I usually don't have a graphical file manager at all.)