### PR TITLE
Fix emojis.bin reading on big-endian systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,12 @@ if (WIN32)
     add_compile_definitions(NOMINMAX)
 endif ()
 
+include(TestBigEndian)
+test_big_endian(IS_BIG_ENDIAN)
+if (IS_BIG_ENDIAN)
+    add_compile_definitions(ABADDON_IS_BIG_ENDIAN)
+endif ()
+
 configure_file(${PROJECT_SOURCE_DIR}/src/config.h.in ${PROJECT_BINARY_DIR}/config.h)
 
 file(GLOB_RECURSE ABADDON_SOURCES

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Current features:
 * Thread support<sup>3</sup>
 * Animated avatars, server icons, emojis (can be turned off)
 
-1 - Abaddon tries its best to make Discord think it's a legitimate web client. Some of the things done to do this
+1 - Abaddon tries its best (though is not perfect) to make Discord think it's a legitimate web client. Some of the things done to do this
 include: using a browser user agent, sending the same IDENTIFY message that the official web client does, using API v9
 endpoints in all cases, and not using endpoints the web client does not normally use. There are still a few smaller
 inconsistencies, however. For example the web client sends lots of telemetry via the `/science` endpoint (uBlock origin
-stops this) as well as in the headers of all requests. **In any case,** you should use an official client for joining
-servers, sending new DMs, or managing your friends list if you are afraid of being caught in Discord's spam filters
-(unlikely).
+stops this) as well as in the headers of all requests.<br>
+
+**See [here](#the-spam-filter)** for things you might want to avoid if you are worried about being caught in the spam filter.
 
 2 - Unicode emojis are substituted manually as opposed to rendered by GTK on non-Windows platforms. This can be changed
 with the `stock_emojis` setting as shown at the bottom of this README. A CBDT-based font using Twemoji is provided to
@@ -52,6 +52,7 @@ the result of fundamental issues with Discord's thread implementation.
     * mingw-w64-x86_64-curl
     * mingw-w64-x86_64-zlib
     * mingw-w64-x86_64-gtkmm3
+    * mingw-w64-x86_64-libhandy
 2. `git clone --recurse-submodules="subprojects" https://github.com/uowuo/abaddon && cd abaddon`
 3. `mkdir build && cd build`
 4. `cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..`
@@ -60,7 +61,7 @@ the result of fundamental issues with Discord's thread implementation.
 #### Mac:
 
 1. `git clone https://github.com/uowuo/abaddon --recurse-submodules="subprojects" && cd abaddon`
-2. `brew install gtkmm3 nlohmann-json`
+2. `brew install gtkmm3 nlohmann-json libhandy`
 3. `mkdir build && cd build`
 4. `cmake ..`
 5. `make`
@@ -93,6 +94,16 @@ On Linux, `css` and `res` can also be loaded from `~/.local/share/abaddon` or `/
 `abaddon.ini` will also be automatically used if located at `~/.config/abaddon/abaddon.ini` and there is
 no `abaddon.ini` in the working directory
 
+#### The Spam Filter
+
+Discord likes disabling accounts/forcing them to reset their passwords if they think the user is a spam bot or potentially had their account compromised. While the official client still often gets users caught in the spam filter, third party clients tend to upset the spam filter more often. If you get caught by it, you can usually [appeal](https://support.discord.com/hc/en-us/requests/new?ticket_form_id=360000029731) it and get it restored. Here are some things you might want to do with the official client instead if you are particularly afraid of evoking the spam filter's wrath:
+
+* Joining or leaving servers (usually main cause of getting caught)
+* Frequently disconnecting and reconnecting
+* Starting new DMs with people
+* Managing your friends list
+* Managing your user profile while connected to a third party client
+
 #### Dependencies:
 
 * [gtkmm](https://www.gtkmm.org/en/)
@@ -101,6 +112,7 @@ no `abaddon.ini` in the working directory
 * [libcurl](https://curl.se/)
 * [zlib](https://zlib.net/)
 * [SQLite3](https://www.sqlite.org/index.html)
+* [libhandy](https://gnome.pages.gitlab.gnome.org/libhandy/) (optional)
 
 ### TODO:
 

--- a/src/abaddon.cpp
+++ b/src/abaddon.cpp
@@ -648,12 +648,17 @@ void Abaddon::ActionJoinGuildDialog() {
 }
 
 void Abaddon::ActionChannelOpened(Snowflake id, bool expand_to) {
-    if (!id.IsValid() || id == m_main_window->GetChatActiveChannel()) return;
+    if (!id.IsValid()) {
+        m_discord.SetReferringChannel(Snowflake::Invalid);
+        return;
+    }
+    if (id == m_main_window->GetChatActiveChannel()) return;
 
     m_main_window->GetChatWindow()->SetTopic("");
 
     const auto channel = m_discord.GetChannel(id);
     if (!channel.has_value()) {
+        m_discord.SetReferringChannel(Snowflake::Invalid);
         m_main_window->UpdateChatActiveChannel(Snowflake::Invalid, false);
         m_main_window->UpdateChatWindowContents();
         return;
@@ -702,6 +707,7 @@ void Abaddon::ActionChannelOpened(Snowflake id, bool expand_to) {
     }
 
     m_main_window->UpdateMenus();
+    m_discord.SetReferringChannel(id);
 }
 
 void Abaddon::ActionChatLoadHistory(Snowflake id) {

--- a/src/components/chatmessage.hpp
+++ b/src/components/chatmessage.hpp
@@ -2,7 +2,7 @@
 #include <gtkmm.h>
 #include "discord/discord.hpp"
 
-class ChatMessageItemContainer : public Gtk::Box {
+class ChatMessageItemContainer : public Gtk::EventBox {
 public:
     Snowflake ID;
     Snowflake ChannelID;
@@ -44,6 +44,7 @@ protected:
     void HandleChannelMentions(const Glib::RefPtr<Gtk::TextBuffer> &buf);
     void HandleChannelMentions(Gtk::TextView *tv);
     bool OnClickChannel(GdkEventButton *ev);
+    bool OnTextViewButtonPress(GdkEventButton *ev);
 
     // reused for images and links
     Gtk::Menu m_link_menu;
@@ -56,8 +57,6 @@ protected:
     bool OnLinkClick(GdkEventButton *ev);
     std::map<Glib::RefPtr<Gtk::TextTag>, std::string> m_link_tagmap;
     std::map<Glib::RefPtr<Gtk::TextTag>, Snowflake> m_channel_tagmap;
-
-    void AttachEventHandlers(Gtk::Widget &widget);
 
     Gtk::EventBox *_ev;
     Gtk::Box m_main;

--- a/src/discord/discord.cpp
+++ b/src/discord/discord.cpp
@@ -610,19 +610,6 @@ void DiscordClient::UpdateStatus(PresenceStatus status, bool is_afk, const Activ
     m_signal_presence_update.emit(GetUserData(), status);
 }
 
-void DiscordClient::CreateDM(Snowflake user_id, const sigc::slot<void(DiscordError code, Snowflake channel_id)> &callback) {
-    CreateDMObject obj;
-    obj.Recipients.push_back(user_id);
-    m_http.MakePOST("/users/@me/channels", nlohmann::json(obj).dump(), [callback](const http::response &response) {
-        if (!CheckCode(response)) {
-            callback(DiscordError::NONE, Snowflake::Invalid);
-            return;
-        }
-        auto channel = nlohmann::json::parse(response.text).get<ChannelData>();
-        callback(GetCodeFromResponse(response), channel.ID);
-    });
-}
-
 void DiscordClient::CloseDM(Snowflake channel_id) {
     m_http.MakeDELETE("/channels/" + std::to_string(channel_id), [](const http::response &response) {
         CheckCode(response);

--- a/src/discord/discord.hpp
+++ b/src/discord/discord.hpp
@@ -204,6 +204,8 @@ public:
     void GetVerificationGateInfo(Snowflake guild_id, const sigc::slot<void(std::optional<VerificationGateInfoObject>)> &callback);
     void AcceptVerificationGate(Snowflake guild_id, VerificationGateInfoObject info, const sigc::slot<void(DiscordError code)> &callback);
 
+    void SetReferringChannel(Snowflake id);
+
     void UpdateToken(const std::string &token);
     void SetUserAgent(const std::string &agent);
 
@@ -284,6 +286,9 @@ private:
     void HeartbeatThread();
     void SendIdentify();
     void SendResume();
+
+    void SetHeaders();
+    void SetSuperPropertiesFromIdentity(const IdentifyMessage &identity);
 
     void HandleSocketOpen();
     void HandleSocketClose(uint16_t code);

--- a/src/discord/discord.hpp
+++ b/src/discord/discord.hpp
@@ -119,7 +119,6 @@ public:
     void BanUser(Snowflake user_id, Snowflake guild_id); // todo: reason, delete messages
     void UpdateStatus(PresenceStatus status, bool is_afk);
     void UpdateStatus(PresenceStatus status, bool is_afk, const ActivityData &obj);
-    void CreateDM(Snowflake user_id, const sigc::slot<void(DiscordError code, Snowflake channel_id)> &callback);
     void CloseDM(Snowflake channel_id);
     std::optional<Snowflake> FindDM(Snowflake user_id); // wont find group dms
     void AddReaction(Snowflake id, Glib::ustring param);

--- a/src/discord/httpclient.cpp
+++ b/src/discord/httpclient.cpp
@@ -19,11 +19,17 @@ void HTTPClient::SetAuth(std::string auth) {
     m_authorization = std::move(auth);
 }
 
+void HTTPClient::SetPersistentHeader(std::string name, std::string value) {
+    m_headers.insert_or_assign(std::move(name), std::move(value));
+}
+
 void HTTPClient::MakeDELETE(const std::string &path, const std::function<void(http::response_type r)> &cb) {
     printf("DELETE %s\n", path.c_str());
     m_futures.push_back(std::async(std::launch::async, [this, path, cb] {
         http::request req(http::REQUEST_DELETE, m_api_base + path);
+        AddHeaders(req);
         req.set_header("Authorization", m_authorization);
+        req.set_header("Origin", "https://discord.com");
         req.set_user_agent(!m_agent.empty() ? m_agent : "Abaddon");
 #ifdef USE_LOCAL_PROXY
         req.set_proxy("http://127.0.0.1:8888");
@@ -40,8 +46,10 @@ void HTTPClient::MakePATCH(const std::string &path, const std::string &payload, 
     printf("PATCH %s\n", path.c_str());
     m_futures.push_back(std::async(std::launch::async, [this, path, cb, payload] {
         http::request req(http::REQUEST_PATCH, m_api_base + path);
+        AddHeaders(req);
         req.set_header("Authorization", m_authorization);
         req.set_header("Content-Type", "application/json");
+        req.set_header("Origin", "https://discord.com");
         req.set_user_agent(!m_agent.empty() ? m_agent : "Abaddon");
         req.set_body(payload);
 #ifdef USE_LOCAL_PROXY
@@ -59,8 +67,10 @@ void HTTPClient::MakePOST(const std::string &path, const std::string &payload, c
     printf("POST %s\n", path.c_str());
     m_futures.push_back(std::async(std::launch::async, [this, path, cb, payload] {
         http::request req(http::REQUEST_POST, m_api_base + path);
+        AddHeaders(req);
         req.set_header("Authorization", m_authorization);
         req.set_header("Content-Type", "application/json");
+        req.set_header("Origin", "https://discord.com");
         req.set_user_agent(!m_agent.empty() ? m_agent : "Abaddon");
         req.set_body(payload);
 #ifdef USE_LOCAL_PROXY
@@ -78,7 +88,9 @@ void HTTPClient::MakePUT(const std::string &path, const std::string &payload, co
     printf("PUT %s\n", path.c_str());
     m_futures.push_back(std::async(std::launch::async, [this, path, cb, payload] {
         http::request req(http::REQUEST_PUT, m_api_base + path);
+        AddHeaders(req);
         req.set_header("Authorization", m_authorization);
+        req.set_header("Origin", "https://discord.com");
         if (!payload.empty())
             req.set_header("Content-Type", "application/json");
         req.set_user_agent(!m_agent.empty() ? m_agent : "Abaddon");
@@ -98,8 +110,8 @@ void HTTPClient::MakeGET(const std::string &path, const std::function<void(http:
     printf("GET %s\n", path.c_str());
     m_futures.push_back(std::async(std::launch::async, [this, path, cb] {
         http::request req(http::REQUEST_GET, m_api_base + path);
+        AddHeaders(req);
         req.set_header("Authorization", m_authorization);
-        req.set_header("Content-Type", "application/json");
         req.set_user_agent(!m_agent.empty() ? m_agent : "Abaddon");
 #ifdef USE_LOCAL_PROXY
         req.set_proxy("http://127.0.0.1:8888");
@@ -145,6 +157,13 @@ void HTTPClient::RunCallbacks() {
     m_queue.front()();
     m_queue.pop();
     m_mutex.unlock();
+}
+
+void HTTPClient::AddHeaders(http::request &r) {
+    for (const auto &[name, val] : m_headers) {
+        r.set_header(name, val);
+    }
+    curl_easy_setopt(r.get_curl(), CURLOPT_ACCEPT_ENCODING, "gzip, deflate, br");
 }
 
 void HTTPClient::OnResponse(const http::response_type &r, const std::function<void(http::response_type r)> &cb) {

--- a/src/discord/httpclient.hpp
+++ b/src/discord/httpclient.hpp
@@ -17,6 +17,8 @@ public:
 
     void SetUserAgent(std::string agent);
     void SetAuth(std::string auth);
+    void SetPersistentHeader(std::string name, std::string value);
+
     void MakeDELETE(const std::string &path, const std::function<void(http::response_type r)> &cb);
     void MakeGET(const std::string &path, const std::function<void(http::response_type r)> &cb);
     void MakePATCH(const std::string &path, const std::string &payload, const std::function<void(http::response_type r)> &cb);
@@ -27,6 +29,8 @@ public:
     void Execute(http::request &&req, const std::function<void(http::response_type r)> &cb);
 
 private:
+    void AddHeaders(http::request &r);
+
     void OnResponse(const http::response_type &r, const std::function<void(http::response_type r)> &cb);
     void CleanupFutures();
 
@@ -39,4 +43,5 @@ private:
     std::string m_api_base;
     std::string m_authorization;
     std::string m_agent;
+    std::unordered_map<std::string, std::string> m_headers;
 };

--- a/src/discord/objects.cpp
+++ b/src/discord/objects.cpp
@@ -262,6 +262,7 @@ void to_json(nlohmann::json &j, const ClientStateProperties &m) {
     j["highest_last_message_id"] = m.HighestLastMessageID;
     j["read_state_version"] = m.ReadStateVersion;
     j["user_guild_settings_version"] = m.UserGuildSettingsVersion;
+    j["user_settings_version"] = m.UserSettingsVersion;
 }
 
 void to_json(nlohmann::json &j, const IdentifyMessage &m) {

--- a/src/discord/objects.hpp
+++ b/src/discord/objects.hpp
@@ -382,6 +382,7 @@ struct ClientStateProperties {
     std::string HighestLastMessageID = "0";
     int ReadStateVersion = 0;
     int UserGuildSettingsVersion = -1;
+    int UserSettingsVersion = -1;
 
     friend void to_json(nlohmann::json &j, const ClientStateProperties &m);
 };

--- a/src/discord/store.cpp
+++ b/src/discord/store.cpp
@@ -254,6 +254,14 @@ void Store::SetGuildMember(Snowflake guild_id, Snowflake user_id, const GuildMem
     s->Reset();
 
     {
+        auto &s = m_stmt_clr_member_roles;
+        s->Bind(1, user_id);
+        s->Bind(2, guild_id);
+        s->Step();
+        s->Reset();
+    }
+
+    {
         auto &s = m_stmt_set_member_roles;
 
         BeginTransaction();
@@ -1879,6 +1887,20 @@ bool Store::CreateStatements() {
     )");
     if (!m_stmt_get_member_roles->OK()) {
         fprintf(stderr, "failed to prepare get member role statement: %s\n", m_db.ErrStr());
+        return false;
+    }
+
+    m_stmt_clr_member_roles = std::make_unique<Statement>(m_db, R"(
+        DELETE FROM member_roles
+        WHERE user = ? AND
+        EXISTS (
+            SELECT 1 FROM roles
+            WHERE member_roles.role = roles.id
+            AND roles.guild = ?
+        )
+    )");
+    if (!m_stmt_clr_member_roles->OK()) {
+        fprintf(stderr, "failed to prepare clear member roles statement: %s\n", m_db.ErrStr());
         return false;
     }
 

--- a/src/discord/store.hpp
+++ b/src/discord/store.hpp
@@ -281,6 +281,7 @@ private:
     STMT(set_interaction);
     STMT(set_member_roles);
     STMT(get_member_roles);
+    STMT(clr_member_roles);
     STMT(set_guild_emoji);
     STMT(get_guild_emojis);
     STMT(clr_guild_emoji);

--- a/src/emojis.cpp
+++ b/src/emojis.cpp
@@ -2,6 +2,28 @@
 #include <sstream>
 #include <utility>
 
+#include <stdio.h>
+
+/* Pre-processor hack for byte order conversions */
+#if defined __BYTE_ORDER__
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+/* this might not work on BSD's... only tested on Linux with GCC/glibc on
+   powerpc 32-bit (Powerbook G4). */
+#include <byteswap.h>
+int emojis_bin_proc_int(int input) {
+    return (int)__bswap_32((uint32_t)input);
+}
+#else
+int emojis_bin_proc_int(int input) {
+  return input;
+}
+#endif /* __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__ */
+#else /* no modern windows uses big endian... hope this is enough. */
+int emojis_bin_proc_int(int input) {
+  return input;
+}
+#endif /* defined __BYTE_ORDER__ */
+
 EmojiResource::EmojiResource(std::string filepath)
     : m_filepath(std::move(filepath)) {}
 
@@ -11,18 +33,22 @@ bool EmojiResource::Load() {
 
     int index_offset;
     std::fread(&index_offset, 4, 1, m_fp);
+    index_offset=emojis_bin_proc_int(index_offset);
     std::fseek(m_fp, index_offset, SEEK_SET);
 
     int emojis_count;
     std::fread(&emojis_count, 4, 1, m_fp);
+    emojis_count=emojis_bin_proc_int(emojis_count);
     for (int i = 0; i < emojis_count; i++) {
         std::vector<std::string> shortcodes;
 
         int shortcodes_count;
         std::fread(&shortcodes_count, 4, 1, m_fp);
+        shortcodes_count=emojis_bin_proc_int(shortcodes_count);
         for (int j = 0; j < shortcodes_count; j++) {
             int shortcode_length;
             std::fread(&shortcode_length, 4, 1, m_fp);
+            shortcode_length=emojis_bin_proc_int(shortcode_length);
             std::string shortcode(shortcode_length, '\0');
             std::fread(shortcode.data(), shortcode_length, 1, m_fp);
             shortcodes.push_back(std::move(shortcode));
@@ -30,13 +56,16 @@ bool EmojiResource::Load() {
 
         int surrogates_count;
         std::fread(&surrogates_count, 4, 1, m_fp);
+        surrogates_count=emojis_bin_proc_int(surrogates_count);
         std::string surrogates(surrogates_count, '\0');
         std::fread(surrogates.data(), surrogates_count, 1, m_fp);
         m_patterns.emplace_back(surrogates);
 
         int data_size, data_offset;
         std::fread(&data_size, 4, 1, m_fp);
+        data_size=emojis_bin_proc_int(data_size);
         std::fread(&data_offset, 4, 1, m_fp);
+        data_offset=emojis_bin_proc_int(data_offset);
         m_index[surrogates] = { data_offset, data_size };
 
         for (const auto &shortcode : shortcodes)

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -98,6 +98,10 @@ void request::set_user_agent(const std::string &data) {
     curl_easy_setopt(m_curl, CURLOPT_USERAGENT, data.c_str());
 }
 
+CURL *request::get_curl() {
+    return m_curl;
+}
+
 void request::make_form() {
     m_form = curl_mime_init(m_curl);
 }

--- a/src/http.hpp
+++ b/src/http.hpp
@@ -122,6 +122,8 @@ struct request {
 
     response execute();
 
+    CURL *get_curl();
+
 private:
     void prepare();
 


### PR DESCRIPTION
This works, but the code itself might or might not be good enough for you the way I implemented it.

It at least works on my 32-bit big-endian PowerBook G4... and I think the preprocessor if's I used should prevent it from interfering with Windows. But I don't know how it will play out on the BSD's, for instance, which may or may not define `__BYTE_ORDER__` and `__ORDER_BIG_ENDIAN__`.

Endianness could be checked at runtime with something like this instead, and avoid a whole lot of headaches.

    int e = 1; // Check Endianness
        if ((int)*((unsigned char *)&e) == 1) { // Little Endian
            ......
        }
        else { // Big Endian
            ......
        }

Stealing from https://stackoverflow.com/a/2182184 , here's some relatively portable 32-bit endian-swapping code.

    swapped = ((num>>24)&0xff) | // move byte 3 to byte 0
                    ((num<<8)&0xff0000) | // move byte 1 to byte 2
                    ((num>>8)&0xff00) | // move byte 2 to byte 1
                    ((num<<24)&0xff000000); // byte 0 to byte 3

But I thought I'd give you some code and also let you know there was a problem, at the very least. I can confirm that my code makes emojis decode correctly on Big Endian PowerPC Linux.

Note that if anyone else tries this, in order to get it to actually build on PowerPC 32-bit, I had to add the `-latomic` flag manually to the linking command... that's not because of my code, it was already like that. But just in case someone is trying to do this in the future and stumbles on this, there you go.