### PR TITLE
cstdio include no longer needed (oops)

### DIFF
--- a/src/emojis.cpp
+++ b/src/emojis.cpp
@@ -1,7 +1,6 @@
 #include "emojis.hpp"
 #include <sstream>
 #include <utility>
-#include <cstdio>
 
 #ifdef ABADDON_IS_BIG_ENDIAN
 /* Allows processing emojis.bin correctly on big-endian systems. */


### PR DESCRIPTION
Sorry I missed this earlier... the `<cstdio>` include was there because I was printing out some numbers while debugging to make sure the big/little endian thing was in fact the issue causing `emojis.bin` decoding to fail. I had `fprintf()`'s scattered about.

Those are no longer there, so `#include <cstdio>` is no longer needed. So a one line PR.