### PR TITLE
WIP: Embed override

### DIFF
--- a/src/components/chatmessage.cpp
+++ b/src/components/chatmessage.cpp
@@ -55,7 +55,7 @@ ChatMessageItemContainer *ChatMessageItemContainer::FromMessage(const Message &d
             auto *widget = container->CreateImageComponent(a.ProxyURL, a.URL, *a.Width, *a.Height);
             container->m_main.add(*widget);
         } else if (IsURLOverrideImage(a.ProxyURL)) {
-            auto *widget = container->CreateOverrideImageComponent(a.ProxyURL, a.URL, 200, 200);
+            auto *widget = container->CreateOverrideImageComponent(a.URL);
             container->m_main.add(*widget);
         } else {
             auto *widget = container->CreateAttachmentComponent(a);
@@ -510,13 +510,16 @@ Gtk::Widget *ChatMessageItemContainer::CreateImageComponent(const std::string &p
 
     return ev;
 }
+/// TODO; this should not be default behavior and only opt in
 
-Gtk::Widget *ChatMessageItemContainer::CreateOverrideImageComponent(const std::string &proxy_url, const std::string &url, int inw, int inh) {
-    int w, h;
-    GetImageDimensions(inw, inh, w, h);
+Gtk::Widget *ChatMessageItemContainer::CreateOverrideImageComponent(const std::string &url) {
+    //debug
+    int w = 200;
+    int h = 200;
+    const bool is_animated = true;
 
     Gtk::EventBox *ev = Gtk::manage(new Gtk::EventBox);
-    Gtk::Image *widget = Gtk::manage(new LazyImage(url, w, h, false));
+    Gtk::Image *widget = Gtk::manage(new LazyImage(url, w, h, true)); //debug
     ev->add(*widget);
     ev->set_halign(Gtk::ALIGN_START);
     widget->set_halign(Gtk::ALIGN_START);

--- a/src/components/chatmessage.hpp
+++ b/src/components/chatmessage.hpp
@@ -25,6 +25,7 @@ protected:
     Gtk::Widget *CreateEmbedsComponent(const std::vector<EmbedData> &embeds);
     static Gtk::Widget *CreateEmbedComponent(const EmbedData &data); // Message.Embeds[0]
     Gtk::Widget *CreateImageComponent(const std::string &proxy_url, const std::string &url, int inw, int inh);
+    Gtk::Widget *CreateOverrideImageComponent(const std::string &proxy_url, const std::string &url, int inw, int inh);
     Gtk::Widget *CreateAttachmentComponent(const AttachmentData &data); // non-image attachments
     Gtk::Widget *CreateStickersComponent(const std::vector<StickerItem> &data);
     Gtk::Widget *CreateReactionsComponent(const Message &data);

--- a/src/components/chatmessage.hpp
+++ b/src/components/chatmessage.hpp
@@ -25,7 +25,7 @@ protected:
     Gtk::Widget *CreateEmbedsComponent(const std::vector<EmbedData> &embeds);
     static Gtk::Widget *CreateEmbedComponent(const EmbedData &data); // Message.Embeds[0]
     Gtk::Widget *CreateImageComponent(const std::string &proxy_url, const std::string &url, int inw, int inh);
-    Gtk::Widget *CreateOverrideImageComponent(const std::string &proxy_url, const std::string &url, int inw, int inh);
+    Gtk::Widget *CreateOverrideImageComponent(const std::string &url);
     Gtk::Widget *CreateAttachmentComponent(const AttachmentData &data); // non-image attachments
     Gtk::Widget *CreateStickersComponent(const std::vector<StickerItem> &data);
     Gtk::Widget *CreateReactionsComponent(const Message &data);

--- a/src/components/lazyimage.hpp
+++ b/src/components/lazyimage.hpp
@@ -13,7 +13,7 @@ public:
 private:
     bool OnDraw(const Cairo::RefPtr<Cairo::Context> &context);
 
-    bool m_animated = false;
+    bool m_animated = true; //debug
     bool m_needs_request = true;
     std::string m_url;
     int m_width;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -175,6 +175,9 @@ bool IsURLViewableImage(const std::string &url) {
 bool IsURLOverrideImage(const std::string &url) {
     const auto ext = GetExtension(url);
     static const char *exts[] = { ".avif",
+                                  ".svg",
+                                  ".gif",
+                                  ".webp",
                                   ".jxl", nullptr };
     const char *str = ext.c_str();
     for (int i = 0; exts[i] != nullptr; i++)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -172,6 +172,17 @@ bool IsURLViewableImage(const std::string &url) {
     return false;
 }
 
+bool IsURLOverrideImage(const std::string &url) {
+    const auto ext = GetExtension(url);
+    static const char *exts[] = { ".avif",
+                                  ".jxl", nullptr };
+    const char *str = ext.c_str();
+    for (int i = 0; exts[i] != nullptr; i++)
+        if (strcmp(str, exts[i]) == 0)
+            return true;
+    return false;
+}
+
 void AddPointerCursor(Gtk::Widget &widget) {
     widget.signal_realize().connect([&widget]() {
         auto window = widget.get_window();

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -39,6 +39,7 @@ void AddWidgetMenuHandler(Gtk::Widget *widget, Gtk::Menu &menu, const sigc::slot
 std::vector<std::string> StringSplit(const std::string &str, const char *delim);
 std::string GetExtension(std::string url);
 bool IsURLViewableImage(const std::string &url);
+bool IsURLOverrideImage(const std::string &url);
 std::vector<uint8_t> ReadWholeFile(const std::string &path);
 std::string HumanReadableBytes(uint64_t bytes);
 std::string FormatISO8601(const std::string &in, int extra_offset = 0, const std::string &fmt = "%x %X");


### PR DESCRIPTION
this is a WIP to allow other formats then the ones that discord allows to be embedded

TODO:
- [ ] Add a toggle to disable, since this will load the enitre picture itself. loading the picture by default is probably undesired behavior
- [ ] Properly set resolution instead of forcing it inro 200x200
- [ ] Detect if picture is animated, normal webp files are already supported. and gifs will load too if the animation flag is set. without needing to be in override category
- [ ] Reduce code dupe

Im not sure the best way to go about handling resolution at this time.
EDIT: addresses #103 