### PR TITLE
readme: list exact depedency package names for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ the result of fundamental issues with Discord's thread implementation.
 
 #### Linux:
 
-1. Install dependencies: `libgtkmm-3.0-dev`, `libcurl4-gnutls-dev`,
-   and [nlohmann-json](https://github.com/nlohmann/json)
+1. Install dependencies
+    * On Ubuntu 20.04 (Focal) and newer:
+      ```Shell
+      $ sudo apt install g++ cmake libgtkmm-3.0-dev libcurl4-gnutls-dev libsqlite3-dev libssl-dev nlohmann-json3-dev
+      ```
 2. `git clone https://github.com/uowuo/abaddon --recurse-submodules="subprojects" && cd abaddon`
 3. `mkdir build && cd build`
 4. `cmake ..`


### PR DESCRIPTION
Sometimes it's annoying to pinpoint the right package for a given distribution. Starting off the list with Ubuntu 22.04+ (tested). Package names for other distros can be added by good samaritans as they pass by.