### PR TITLE
Make README.md more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ spam filter's wrath:
 
 #### CSS selectors
 
+```css
 .app-window - Applied to all windows. This means the main window and all popups  
 .app-popup - Additional class for `.app-window`s when the window is not the main window
 
@@ -219,6 +220,7 @@ Used in profile popup:
 .profile-stack - Container for profile info that can be switched between  
 .profile-badges - Container for badges  
 .profile-badge
+```
 
 ### Settings
 

--- a/README.md
+++ b/README.md
@@ -135,92 +135,90 @@ spam filter's wrath:
 
 #### CSS selectors
 
-```css
-.app-window - Applied to all windows. This means the main window and all popups  
-.app-popup - Additional class for `.app-window`s when the window is not the main window
+`.app-window` - Applied to all windows. This means the main window and all popups   
+`.app-popup` - Additional class for `.app-window`s when the window is not the main window
 
-.channel-list - Container of the channel list
+`.channel-list` - Container of the channel list
 
-.messages - Container of user messages  
-.message-container - The container which holds a user's messages  
-.message-container-author - The author label for a message container  
-.message-container-timestamp - The timestamp label for a message container  
-.message-container-avatar - Avatar for a user in a message  
-.message-container-extra - Label containing BOT/Webhook  
-.message-text - The text of a user message  
-.pending - Extra class of .message-text for messages pending to be sent  
-.failed - Extra class of .message-text for messages that failed to be sent   
-.message-attachment-box - Contains attachment info  
-.message-reply - Container for the replied-to message in a reply (these elements will also have .message-text set)  
-.message-input - Applied to the chat input container  
-.replying - Extra class for chat input container when a reply is currently being created  
-.reaction-box - Contains a reaction image and the count  
-.reacted - Additional class for reaction-box when the user has reacted with a particular reaction  
-.reaction-count - Contains the count for reaction
+`.messages` - Container of user messages  
+`.message-container` - The container which holds a user's messages  
+`.message-container-author` - The author label for a message container  
+`.message-container-timestamp` - The timestamp label for a message container  
+`.message-container-avatar` - Avatar for a user in a message  
+`.message-container-extra` - Label containing BOT/Webhook  
+`.message-text` - The text of a user message  
+`.pending` - Extra class of .message-text for messages pending to be sent  
+`.failed` - Extra class of .message-text for messages that failed to be sent   
+`.message-attachment-box` - Contains attachment info  
+`.message-reply` - Container for the replied-to message in a reply (these elements will also have .message-text set)  
+`.message-input` - Applied to the chat input container  
+`.replying` - Extra class for chat input container when a reply is currently being created  
+`.reaction-box` - Contains a reaction image and the count  
+`.reacted` - Additional class for reaction-box when the user has reacted with a particular reaction  
+`.reaction-count` - Contains the count for reaction
 
-.completer - Container for the message completer  
-.completer-entry - Container for a single entry in the completer  
-.completer-entry-label - Contains the label for an entry in the completer  
-.completer-entry-image - Contains the image for an entry in the completer
+`.completer` - Container for the message completer  
+`.completer-entry` - Container for a single entry in the completer  
+`.completer-entry-label` - Contains the label for an entry in the completer  
+`.completer-entry-image` - Contains the image for an entry in the completer
 
-.embed - Container for a message embed  
-.embed-author - The author of an embed  
-.embed-title - The title of an embed  
-.embed-description - The description of an embed  
-.embed-field-title - The title of an embed field  
-.embed-field-value - The value of an embed field  
-.embed-footer - The footer of an embed
+`.embed` - Container for a message embed  
+`.embed-author` - The author of an embed  
+`.embed-title` - The title of an embed  
+`.embed-description` - The description of an embed  
+`.embed-field-title` - The title of an embed field  
+`.embed-field-value` - The value of an embed field  
+`.embed-footer` - The footer of an embed
 
-.members - Container of the member list  
-.members-row - All rows within the members container  
-.members-row-label - All labels in the members container  
-.members-row-member - Rows containing a member  
-.members-row-role - Rows containing a role  
-.members-row-avatar - Contains the avatar for a row in the member list
+`.members` - Container of the member list  
+`.members-row` - All rows within the members container  
+`.members-row-label` - All labels in the members container  
+`.members-row-member` - Rows containing a member  
+`.members-row-role` - Rows containing a role  
+`.members-row-avatar` - Contains the avatar for a row in the member list
 
-.status-indicator - The status indicator  
-.online - Applied to status indicators when the associated user is online  
-.idle - Applied to status indicators when the associated user is away  
-.dnd - Applied to status indicators when the associated user is on do not disturb  
-.offline - Applied to status indicators when the associated user is offline
+`.status-indicator` - The status indicator  
+`.online` - Applied to status indicators when the associated user is online  
+`.idle` - Applied to status indicators when the associated user is away  
+`.dnd` - Applied to status indicators when the associated user is on do not disturb  
+`.offline` - Applied to status indicators when the associated user is offline
 
-.typing-indicator - The typing indicator (also used for replies)
+`.typing-indicator` - The typing indicator (also used for replies)
 
 Used in reorderable list implementation:  
-.drag-icon .drag-hover-top .drag-hover-bottom
+`.drag-icon` `.drag-hover-top` `.drag-hover-bottom`
 
 Used in guild settings popup:  
-.guild-settings-window  
-.guild-members-pane-list - Container for list of members in the members pane  
-.guild-members-pane-info - Container for member info  
-.guild-roles-pane-list - Container for list of roles in the roles pane
+`.guild-settings-window`  
+`.guild-members-pane-list` - Container for list of members in the members pane  
+`.guild-members-pane-info` - Container for member info  
+`.guild-roles-pane-list` - Container for list of roles in the roles pane
 
 Used in profile popup:  
-.mutual-friend-item - Applied to every item in the mutual friends list  
-.mutual-friend-item-name - Name in mutual friend item  
-.mutual-friend-item-avatar - Avatar in mutual friend item   
-.mutual-guild-item - Applied to every item in the mutual guilds list  
-.mutual-guild-item-name - Name in mutual guild item  
-.mutual-guild-item-icon - Icon in mutual guild item  
-.mutual-guild-item-nick - User nickname in mutual guild item  
-.profile-connection - Applied to every item in the user connections list  
-.profile-connection-label - Label in profile connection item  
-.profile-connection-check - Checkmark in verified profile connection items  
-.profile-connections - Container for profile connections  
-.profile-notes - Container for notes in profile window  
-.profile-notes-label - Label that says "NOTE"  
-.profile-notes-text - Actual note text  
-.profile-info-pane - Applied to container for info section of profile popup  
-.profile-info-created - Label for creation date of profile  
-.user-profile-window  
-.profile-main-container - Inner container for profile  
-.profile-avatar  
-.profile-username  
-.profile-switcher - Buttons used to switch viewed section of profile  
-.profile-stack - Container for profile info that can be switched between  
-.profile-badges - Container for badges  
-.profile-badge
-```
+`.mutual-friend-item` - Applied to every item in the mutual friends list  
+`.mutual-friend-item-name` - Name in mutual friend item  
+`.mutual-friend-item-avatar` - Avatar in mutual friend item   
+`.mutual-guild-item` - Applied to every item in the mutual guilds list  
+`.mutual-guild-item-name` - Name in mutual guild item  
+`.mutual-guild-item-icon` - Icon in mutual guild item  
+`.mutual-guild-item-nick` - User nickname in mutual guild item  
+`.profile-connection` - Applied to every item in the user connections list  
+`.profile-connection-label` - Label in profile connection item  
+`.profile-connection-check` - Checkmark in verified profile connection items  
+`.profile-connections` - Container for profile connections  
+`.profile-notes` - Container for notes in profile window  
+`.profile-notes-label` - Label that says "NOTE"  
+`.profile-notes-text` - Actual note text  
+`.profile-info-pane` - Applied to container for info section of profile popup  
+`.profile-info-created` - Label for creation date of profile  
+`.user-profile-window`  
+`.profile-main-container` - Inner container for profile  
+`.profile-avatar`  
+`.profile-username`  
+`.profile-switcher` - Buttons used to switch viewed section of profile  
+`.profile-stack` - Container for profile info that can be switched between  
+`.profile-badges` - Container for badges  
+`.profile-badge`
 
 ### Settings
 

--- a/README.md
+++ b/README.md
@@ -135,90 +135,90 @@ spam filter's wrath:
 
 #### CSS selectors
 
-`.app-window` - Applied to all windows. This means the main window and all popups   
-`.app-popup` - Additional class for `.app-window`s when the window is not the main window
+**`.app-window`** - Applied to all windows. This means the main window and all popups   
+**`.app-popup`** - Additional class for `.app-window`s when the window is not the main window
 
-`.channel-list` - Container of the channel list
+**`.channel-list`** - Container of the channel list
 
-`.messages` - Container of user messages  
-`.message-container` - The container which holds a user's messages  
-`.message-container-author` - The author label for a message container  
-`.message-container-timestamp` - The timestamp label for a message container  
-`.message-container-avatar` - Avatar for a user in a message  
-`.message-container-extra` - Label containing BOT/Webhook  
-`.message-text` - The text of a user message  
-`.pending` - Extra class of .message-text for messages pending to be sent  
-`.failed` - Extra class of .message-text for messages that failed to be sent   
-`.message-attachment-box` - Contains attachment info  
-`.message-reply` - Container for the replied-to message in a reply (these elements will also have .message-text set)  
-`.message-input` - Applied to the chat input container  
-`.replying` - Extra class for chat input container when a reply is currently being created  
-`.reaction-box` - Contains a reaction image and the count  
-`.reacted` - Additional class for reaction-box when the user has reacted with a particular reaction  
-`.reaction-count` - Contains the count for reaction
+**`.messages`** - Container of user messages  
+**`.message-container`** - The container which holds a user's messages  
+**`.message-container-author`** - The author label for a message container  
+**`.message-container-timestamp`** - The timestamp label for a message container  
+**`.message-container-avatar`** - Avatar for a user in a message  
+**`.message-container-extra`** - Label containing BOT/Webhook  
+**`.message-text`** - The text of a user message  
+**`.pending`** - Extra class of .message-text for messages pending to be sent  
+**`.failed`** - Extra class of .message-text for messages that failed to be sent   
+**`.message-attachment-box`** - Contains attachment info  
+**`.message-reply`** - Container for the replied-to message in a reply (these elements will also have .message-text set)  
+**`.message-input`** - Applied to the chat input container  
+**`.replying`** - Extra class for chat input container when a reply is currently being created  
+**`.reaction-box`** - Contains a reaction image and the count  
+**`.reacted`** - Additional class for reaction-box when the user has reacted with a particular reaction  
+**`.reaction-count`** - Contains the count for reaction
 
-`.completer` - Container for the message completer  
-`.completer-entry` - Container for a single entry in the completer  
-`.completer-entry-label` - Contains the label for an entry in the completer  
-`.completer-entry-image` - Contains the image for an entry in the completer
+**`.completer`** - Container for the message completer  
+**`.completer-entry`** - Container for a single entry in the completer  
+**`.completer-entry-label`** - Contains the label for an entry in the completer  
+**`.completer-entry-image`** - Contains the image for an entry in the completer
 
-`.embed` - Container for a message embed  
-`.embed-author` - The author of an embed  
-`.embed-title` - The title of an embed  
-`.embed-description` - The description of an embed  
-`.embed-field-title` - The title of an embed field  
-`.embed-field-value` - The value of an embed field  
-`.embed-footer` - The footer of an embed
+**`.embed`** - Container for a message embed  
+**`.embed-author`** - The author of an embed  
+**`.embed-title`** - The title of an embed  
+**`.embed-description`** - The description of an embed  
+**`.embed-field-title`** - The title of an embed field  
+**`.embed-field-value`** - The value of an embed field  
+**`.embed-footer`** - The footer of an embed
 
-`.members` - Container of the member list  
-`.members-row` - All rows within the members container  
-`.members-row-label` - All labels in the members container  
-`.members-row-member` - Rows containing a member  
-`.members-row-role` - Rows containing a role  
-`.members-row-avatar` - Contains the avatar for a row in the member list
+**`.members`** - Container of the member list  
+**`.members-row`** - All rows within the members container  
+**`.members-row-label`** - All labels in the members container  
+**`.members-row-member`** - Rows containing a member  
+**`.members-row-role`** - Rows containing a role  
+**`.members-row-avatar`** - Contains the avatar for a row in the member list
 
-`.status-indicator` - The status indicator  
-`.online` - Applied to status indicators when the associated user is online  
-`.idle` - Applied to status indicators when the associated user is away  
-`.dnd` - Applied to status indicators when the associated user is on do not disturb  
-`.offline` - Applied to status indicators when the associated user is offline
+**`.status-indicator`** - The status indicator  
+**`.online`** - Applied to status indicators when the associated user is online  
+**`.idle`** - Applied to status indicators when the associated user is away  
+**`.dnd`** - Applied to status indicators when the associated user is on do not disturb  
+**`.offline`** - Applied to status indicators when the associated user is offline
 
-`.typing-indicator` - The typing indicator (also used for replies)
+**`.typing-indicator`** - The typing indicator (also used for replies)
 
 Used in reorderable list implementation:  
-`.drag-icon` `.drag-hover-top` `.drag-hover-bottom`
+**`.drag-icon`** **`.drag-hover-top`** **`.drag-hover-bottom`**
 
 Used in guild settings popup:  
-`.guild-settings-window`  
-`.guild-members-pane-list` - Container for list of members in the members pane  
-`.guild-members-pane-info` - Container for member info  
-`.guild-roles-pane-list` - Container for list of roles in the roles pane
+**`.guild-settings-window`**  
+**`.guild-members-pane-list`** - Container for list of members in the members pane  
+**`.guild-members-pane-info`** - Container for member info  
+**`.guild-roles-pane-list`** - Container for list of roles in the roles pane
 
 Used in profile popup:  
-`.mutual-friend-item` - Applied to every item in the mutual friends list  
-`.mutual-friend-item-name` - Name in mutual friend item  
-`.mutual-friend-item-avatar` - Avatar in mutual friend item   
-`.mutual-guild-item` - Applied to every item in the mutual guilds list  
-`.mutual-guild-item-name` - Name in mutual guild item  
-`.mutual-guild-item-icon` - Icon in mutual guild item  
-`.mutual-guild-item-nick` - User nickname in mutual guild item  
-`.profile-connection` - Applied to every item in the user connections list  
-`.profile-connection-label` - Label in profile connection item  
-`.profile-connection-check` - Checkmark in verified profile connection items  
-`.profile-connections` - Container for profile connections  
-`.profile-notes` - Container for notes in profile window  
-`.profile-notes-label` - Label that says "NOTE"  
-`.profile-notes-text` - Actual note text  
-`.profile-info-pane` - Applied to container for info section of profile popup  
-`.profile-info-created` - Label for creation date of profile  
-`.user-profile-window`  
-`.profile-main-container` - Inner container for profile  
-`.profile-avatar`  
-`.profile-username`  
-`.profile-switcher` - Buttons used to switch viewed section of profile  
-`.profile-stack` - Container for profile info that can be switched between  
-`.profile-badges` - Container for badges  
-`.profile-badge`
+**`.mutual-friend-item`** - Applied to every item in the mutual friends list  
+**`.mutual-friend-item-name`** - Name in mutual friend item  
+**`.mutual-friend-item-avatar`** - Avatar in mutual friend item   
+**`.mutual-guild-item`** - Applied to every item in the mutual guilds list  
+**`.mutual-guild-item-name`** - Name in mutual guild item  
+**`.mutual-guild-item-icon`** - Icon in mutual guild item  
+**`.mutual-guild-item-nick`** - User nickname in mutual guild item  
+**`.profile-connection`** - Applied to every item in the user connections list  
+**`.profile-connection-label`** - Label in profile connection item  
+**`.profile-connection-check`** - Checkmark in verified profile connection items  
+**`.profile-connections`** - Container for profile connections  
+**`.profile-notes`** - Container for notes in profile window  
+**`.profile-notes-label`** - Label that says "NOTE"  
+**`.profile-notes-text`** - Actual note text  
+**`.profile-info-pane`** - Applied to container for info section of profile popup  
+**`.profile-info-created`** - Label for creation date of profile  
+**`.user-profile-window`**  
+**`.profile-main-container`** - Inner container for profile  
+**`.profile-avatar`**  
+**`.profile-username`**  
+**`.profile-switcher`** - Buttons used to switch viewed section of profile  
+**`.profile-stack`** - Container for profile info that can be switched between  
+**`.profile-badges`** - Container for badges  
+**`.profile-badge`**
 
 ### Settings
 
@@ -234,46 +234,46 @@ For example, memory_db would be set by adding `memory_db = true` under the line 
 
 #### discord
 
-* `gateway` (string) - override url for Discord gateway. must be json format and use zlib stream compression
-* `api_base` (string) - override base url for Discord API
-* `memory_db` (true or false, `default: false`) - if true, Discord data will be kept in memory as opposed to on disk
-* `token` (string) - Discord token used to login, this can be set from the menu
-* `prefetch` (true or false, `default: false`) - if true, new messages will cause the avatar and image attachments to be
+* **`gateway`** (string) - override url for Discord gateway. must be json format and use zlib stream compression
+* **`api_base`** (string) - override base url for Discord API
+* **`memory_db`** (true or false, `default: false`) - if true, Discord data will be kept in memory as opposed to on disk
+* **`token`** (string) - Discord token used to login, this can be set from the menu
+* **`prefetch`** (true or false, `default: false`) - if true, new messages will cause the avatar and image attachments to be
   automatically downloaded
 
 #### http
 
-* `user_agent` (string) - sets the user-agent to use in HTTP requests to the Discord API (not including media/images)
-* `concurrent` (int, `default: 20`) - how many images can be concurrently retrieved
+* **`user_agent`** (string) - sets the user-agent to use in HTTP requests to the Discord API (not including media/images)
+* **`concurrent`** (int, `default: 20`) - how many images can be concurrently retrieved
 
 #### gui
 
-* `member_list_discriminator` (true or false, `default: true`) - show user discriminators in the member list
-* `stock_emojis` (true or false, `default: true`) - allow abaddon to substitute unicode emojis with images from emojis.bin,
+* **`member_list_discriminator`** (true or false, `default: true`) - show user discriminators in the member list
+* **`stock_emojis`** (true or false, `default: true`) - allow abaddon to substitute unicode emojis with images from emojis.bin,
   must be false to allow GTK to render emojis itself
-* `custom_emojis` (true or false, `default: true`) - download and use custom Discord emojis
-* `css` (string) - path to the main CSS file
-* `animations` (true or false, `default: true`) - use animated images where available (e.g. server icons, emojis, avatars).
+* **`custom_emojis`** (true or false, `default: true`) - download and use custom Discord emojis
+* **`css`** (string) - path to the main CSS file
+* **`animations`** (true or false, `default: true`) - use animated images where available (e.g. server icons, emojis, avatars).
   false means static images will be used
-* `animated_guild_hover_only` (true or false, `default: true`) - only animate guild icons when the guild is being hovered
+* **`animated_guild_hover_only`** (true or false, `default: true`) - only animate guild icons when the guild is being hovered
   over
-* `owner_crown` (true or false, `default: true`) - show a crown next to the owner
-* `unreads` (true or false, `default: true`) - show unread indicators and mention badges
-* `save_state` (true or false, `default: true`) - save the state of the gui (active channels, tabs, expanded channels)
-* `alt_menu` (true or false, `default: false`) - keep the menu hidden unless revealed with alt key
-* `hide_to_tray` (true or false, `default: false`) - hide abaddon to the system tray on window close
+* **`owner_crown`** (true or false, `default: true`) - show a crown next to the owner
+* **`unreads`** (true or false, `default: true`) - show unread indicators and mention badges
+* **`save_state`** (true or false, `default: true`) - save the state of the gui (active channels, tabs, expanded channels)
+* **`alt_menu`** (true or false, `default: false`) - keep the menu hidden unless revealed with alt key
+* **`hide_to_tray`** (true or false, `default: false`) - hide abaddon to the system tray on window close
 
 #### style
 
-* `linkcolor` (string) - color to use for links in messages
-* `expandercolor` (string) - color to use for the expander in the channel list
-* `nsfwchannelcolor` (string) - color to use for NSFW channels in the channel list
-* `channelcolor` (string) - color to use for SFW channels in the channel list
-* `mentionbadgecolor` (string) - background color for mention badges
-* `mentionbadgetextcolor` (string) - color to use for number displayed on mention badges
-* `unreadcolor` (string) - color to use for the unread indicator
+* **`linkcolor`** (string) - color to use for links in messages
+* **`expandercolor`** (string) - color to use for the expander in the channel list
+* **`nsfwchannelcolor`** (string) - color to use for NSFW channels in the channel list
+* **`channelcolor`** (string) - color to use for SFW channels in the channel list
+* **`mentionbadgecolor`** (string) - background color for mention badges
+* **`mentionbadgetextcolor`** (string) - color to use for number displayed on mention badges
+* **`unreadcolor`** (string) - color to use for the unread indicator
 
 ### Environment variables
 
-* `ABADDON_NO_FC` (Windows only) - don't use custom font config
-* `ABADDON_CONFIG` - change path of configuration file to use. relative to cwd or can be absolute
+* **`ABADDON_NO_FC`** (Windows only) - don't use custom font config
+* **`ABADDON_CONFIG`** - change path of configuration file to use. relative to cwd or can be absolute

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Latest release version: https://github.com/uowuo/abaddon/releases/latest
 - Linux: [here](https://nightly.link/uowuo/abaddon/workflows/ci/master/build-linux-MinSizeRel.zip) unpackaged (for now),
   requires gtkmm3. built on Ubuntu 18.04 + gcc9
 
-⚠️ If you use Windows, make sure to start from the `bin` directory
+> **Warning**: If you use Windows, make sure to start from the `bin` directory
 
 On Linux, `css` and `res` can also be loaded from `~/.local/share/abaddon` or `/usr/share/abaddon`
 

--- a/README.md
+++ b/README.md
@@ -234,46 +234,46 @@ For example, memory_db would be set by adding `memory_db = true` under the line 
 
 #### discord
 
-* gateway (string) - override url for Discord gateway. must be json format and use zlib stream compression
-* api_base (string) - override base url for Discord API
-* memory_db (true or false, default false) - if true, Discord data will be kept in memory as opposed to on disk
-* token (string) - Discord token used to login, this can be set from the menu
-* prefetch (true or false, default false) - if true, new messages will cause the avatar and image attachments to be
+* `gateway` (string) - override url for Discord gateway. must be json format and use zlib stream compression
+* `api_base` (string) - override base url for Discord API
+* `memory_db` (true or false, default false) - if true, Discord data will be kept in memory as opposed to on disk
+* `token` (string) - Discord token used to login, this can be set from the menu
+* `prefetch` (true or false, default false) - if true, new messages will cause the avatar and image attachments to be
   automatically downloaded
 
 #### http
 
-* user_agent (string) - sets the user-agent to use in HTTP requests to the Discord API (not including media/images)
-* concurrent (int, default 20) - how many images can be concurrently retrieved
+* `user_agent` (string) - sets the user-agent to use in HTTP requests to the Discord API (not including media/images)
+* `concurrent` (int, default 20) - how many images can be concurrently retrieved
 
 #### gui
 
-* member_list_discriminator (true or false, default true) - show user discriminators in the member list
-* stock_emojis (true or false, default true) - allow abaddon to substitute unicode emojis with images from emojis.bin,
+* `member_list_discriminator` (true or false, default true) - show user discriminators in the member list
+* `stock_emojis` (true or false, default true) - allow abaddon to substitute unicode emojis with images from emojis.bin,
   must be false to allow GTK to render emojis itself
-* custom_emojis (true or false, default true) - download and use custom Discord emojis
-* css (string) - path to the main CSS file
-* animations (true or false, default true) - use animated images where available (e.g. server icons, emojis, avatars).
+* `custom_emojis` (true or false, default true) - download and use custom Discord emojis
+* `css` (string) - path to the main CSS file
+* `animations` (true or false, default true) - use animated images where available (e.g. server icons, emojis, avatars).
   false means static images will be used
-* animated_guild_hover_only (true or false, default true) - only animate guild icons when the guild is being hovered
+* `animated_guild_hover_only` (true or false, default true) - only animate guild icons when the guild is being hovered
   over
-* owner_crown (true or false, default true) - show a crown next to the owner
-* unreads (true or false, default true) - show unread indicators and mention badges
-* save_state (true or false, default true) - save the state of the gui (active channels, tabs, expanded channels)
-* alt_menu (true or false, default false) - keep the menu hidden unless revealed with alt key
-* hide_to_tray (true or false, default false) - hide abaddon to the system tray on window close
+* `owner_crown` (true or false, default true) - show a crown next to the owner
+* `unreads` (true or false, default true) - show unread indicators and mention badges
+* `save_state` (true or false, default true) - save the state of the gui (active channels, tabs, expanded channels)
+* `alt_menu` (true or false, default false) - keep the menu hidden unless revealed with alt key
+* `hide_to_tray` (true or false, default false) - hide abaddon to the system tray on window close
 
 #### style
 
-* linkcolor (string) - color to use for links in messages
-* expandercolor (string) - color to use for the expander in the channel list
-* nsfwchannelcolor (string) - color to use for NSFW channels in the channel list
-* channelcolor (string) - color to use for SFW channels in the channel list
-* mentionbadgecolor (string) - background color for mention badges
-* mentionbadgetextcolor (string) - color to use for number displayed on mention badges
-* unreadcolor (string) - color to use for the unread indicator
+* `linkcolor` (string) - color to use for links in messages
+* `expandercolor` (string) - color to use for the expander in the channel list
+* `nsfwchannelcolor` (string) - color to use for NSFW channels in the channel list
+* `channelcolor` (string) - color to use for SFW channels in the channel list
+* `mentionbadgecolor` (string) - background color for mention badges
+* `mentionbadgetextcolor` (string) - color to use for number displayed on mention badges
+* `unreadcolor` (string) - color to use for the unread indicator
 
 ### Environment variables
 
-* ABADDON_NO_FC (Windows only) - don't use custom font config
-* ABADDON_CONFIG - change path of configuration file to use. relative to cwd or can be absolute
+* `ABADDON_NO_FC` (Windows only) - don't use custom font config
+* `ABADDON_CONFIG` - change path of configuration file to use. relative to cwd or can be absolute

--- a/README.md
+++ b/README.md
@@ -236,32 +236,32 @@ For example, memory_db would be set by adding `memory_db = true` under the line 
 
 * `gateway` (string) - override url for Discord gateway. must be json format and use zlib stream compression
 * `api_base` (string) - override base url for Discord API
-* `memory_db` (true or false, default false) - if true, Discord data will be kept in memory as opposed to on disk
+* `memory_db` (true or false, `default: false`) - if true, Discord data will be kept in memory as opposed to on disk
 * `token` (string) - Discord token used to login, this can be set from the menu
-* `prefetch` (true or false, default false) - if true, new messages will cause the avatar and image attachments to be
+* `prefetch` (true or false, `default: false`) - if true, new messages will cause the avatar and image attachments to be
   automatically downloaded
 
 #### http
 
 * `user_agent` (string) - sets the user-agent to use in HTTP requests to the Discord API (not including media/images)
-* `concurrent` (int, default 20) - how many images can be concurrently retrieved
+* `concurrent` (int, `default: 20`) - how many images can be concurrently retrieved
 
 #### gui
 
-* `member_list_discriminator` (true or false, default true) - show user discriminators in the member list
-* `stock_emojis` (true or false, default true) - allow abaddon to substitute unicode emojis with images from emojis.bin,
+* `member_list_discriminator` (true or false, `default: true`) - show user discriminators in the member list
+* `stock_emojis` (true or false, `default: true`) - allow abaddon to substitute unicode emojis with images from emojis.bin,
   must be false to allow GTK to render emojis itself
-* `custom_emojis` (true or false, default true) - download and use custom Discord emojis
+* `custom_emojis` (true or false, `default: true`) - download and use custom Discord emojis
 * `css` (string) - path to the main CSS file
-* `animations` (true or false, default true) - use animated images where available (e.g. server icons, emojis, avatars).
+* `animations` (true or false, `default: true`) - use animated images where available (e.g. server icons, emojis, avatars).
   false means static images will be used
-* `animated_guild_hover_only` (true or false, default true) - only animate guild icons when the guild is being hovered
+* `animated_guild_hover_only` (true or false, `default: true`) - only animate guild icons when the guild is being hovered
   over
-* `owner_crown` (true or false, default true) - show a crown next to the owner
-* `unreads` (true or false, default true) - show unread indicators and mention badges
-* `save_state` (true or false, default true) - save the state of the gui (active channels, tabs, expanded channels)
-* `alt_menu` (true or false, default false) - keep the menu hidden unless revealed with alt key
-* `hide_to_tray` (true or false, default false) - hide abaddon to the system tray on window close
+* `owner_crown` (true or false, `default: true`) - show a crown next to the owner
+* `unreads` (true or false, `default: true`) - show unread indicators and mention badges
+* `save_state` (true or false, `default: true`) - save the state of the gui (active channels, tabs, expanded channels)
+* `alt_menu` (true or false, `default: false`) - keep the menu hidden unless revealed with alt key
+* `hide_to_tray` (true or false, `default: false`) - hide abaddon to the system tray on window close
 
 #### style
 


### PR DESCRIPTION
## What changed?:

- More **noticeable**  warnings 
- Make `CSS selectors` stand out more from their description
- Make `Settings` options stand out more from their description, and make the default value easy to see

## Preview:
[README.md](https://github.com/Senpai-10/abaddon/blob/better-README/README.md)