### PR TITLE
doc: Display `CSS selectors` and `Settings` as tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,39 +189,41 @@ Used in reorderable list implementation:
 
 Used in guild settings popup:
 
-| Selector                                            | Description                                       |
-|-----------------------------------------------------|---------------------------------------------------|
-| `.guild-settings-window` `.guild-members-pane-list` | Container for list of members in the members pane |
-| `.guild-members-pane-info`                          | Container for member info                         |
-| `.guild-roles-pane-list`                            | Container for list of roles in the roles pane     |
+| Selector                   | Description                                       |
+|----------------------------|---------------------------------------------------|
+| `.guild-settings-window`   | Container for list of members in the members pane |
+| `.guild-members-pane-list` |                                                   |
+| `.guild-members-pane-info` | Container for member info                         |
+| `.guild-roles-pane-list`   | Container for list of roles in the roles pane     |
 
 Used in profile popup:
 
-| Selector                           | Description                                             |
-|------------------------------------|---------------------------------------------------------|
-| `.mutual-friend-item`              | Applied to every item in the mutual friends list        |
-| `.mutual-friend-item-name`         | Name in mutual friend item                              |
-| `.mutual-friend-item-avatar`       | Avatar in mutual friend item                            |
-| `.mutual-guild-item`               | Applied to every item in the mutual guilds list         |
-| `.mutual-guild-item-name`          | Name in mutual guild item                               |
-| `.mutual-guild-item-icon`          | Icon in mutual guild item                               |
-| `.mutual-guild-item-nick`          | User nickname in mutual guild item                      |
-| `.profile-connection`              | Applied to every item in the user connections list      |
-| `.profile-connection-label`        | Label in profile connection item                        |
-| `.profile-connection-check`        | Checkmark in verified profile connection items          |
-| `.profile-connections`             | Container for profile connections                       |
-| `.profile-notes`                   | Container for notes in profile window                   |
-| `.profile-notes-label`             | Label that says "NOTE"                                  |
-| `.profile-notes-text`              | Actual note text                                        |
-| `.profile-info-pane`               | Applied to container for info section of profile popup  |
-| `.profile-info-created`            | Label for creation date of profile                      |
-| `.user-profile-window`             |                                                         |
-| `.profile-main-container`          | Inner container for profile                             |
-| `.profile-avatar`                  |                                                         |
-| `.profile-username`                |                                                         |
-| `.profile-switcher`                | Buttons used to switch viewed section of profile        |
-| `.profile-stack`                   | Container for profile info that can be switched between |
-| `.profile-badges` `.profile-badge` | Container for badges                                    |
+| Selector                     | Description                                             |
+|------------------------------|---------------------------------------------------------|
+| `.mutual-friend-item`        | Applied to every item in the mutual friends list        |
+| `.mutual-friend-item-name`   | Name in mutual friend item                              |
+| `.mutual-friend-item-avatar` | Avatar in mutual friend item                            |
+| `.mutual-guild-item`         | Applied to every item in the mutual guilds list         |
+| `.mutual-guild-item-name`    | Name in mutual guild item                               |
+| `.mutual-guild-item-icon`    | Icon in mutual guild item                               |
+| `.mutual-guild-item-nick`    | User nickname in mutual guild item                      |
+| `.profile-connection`        | Applied to every item in the user connections list      |
+| `.profile-connection-label`  | Label in profile connection item                        |
+| `.profile-connection-check`  | Checkmark in verified profile connection items          |
+| `.profile-connections`       | Container for profile connections                       |
+| `.profile-notes`             | Container for notes in profile window                   |
+| `.profile-notes-label`       | Label that says "NOTE"                                  |
+| `.profile-notes-text`        | Actual note text                                        |
+| `.profile-info-pane`         | Applied to container for info section of profile popup  |
+| `.profile-info-created`      | Label for creation date of profile                      |
+| `.user-profile-window`       |                                                         |
+| `.profile-main-container`    | Inner container for profile                             |
+| `.profile-avatar`            |                                                         |
+| `.profile-username`          |                                                         |
+| `.profile-switcher`          | Buttons used to switch viewed section of profile        |
+| `.profile-stack`             | Container for profile info that can be switched between |
+| `.profile-badges`            | Container for badges                                    |
+| `.profile-badge`             |                                                         |
 
 ### Settings
 

--- a/README.md
+++ b/README.md
@@ -135,93 +135,93 @@ spam filter's wrath:
 
 #### CSS selectors
 
-| Selector    | Description |
-| ----------- | ----------- |
-| `.app-window` | Applied to all windows. This means the main window and all popups |
-| `.app-popup`   | Additional class for `.app-window`s when the window is not the main window |
-| `.channel-list`   | Container of the channel list |
-| `.messages` | Container of user messages |
-| `.message-container` | The container which holds a user's messages |
-| `.message-container-author` | The author label for a message container |
-| `.message-container-timestamp` | The timestamp label for a message container |
-| `.message-container-avatar` | Avatar for a user in a message |
-| `.message-container-extra` | Label containing BOT/Webhook |
-| `.message-text` | The text of a user message |
-| `.pending` | Extra class of .message-text for messages pending to be sent |
-| `.failed` | Extra class of .message-text for messages that failed to be sent |
-| `.message-attachment-box` | Contains attachment info |
-| `.message-reply` | Container for the replied-to message in a reply (these elements will also have .message-text set) |
-| `.message-input` | Applied to the chat input container |
-| `.replying` | Extra class for chat input container when a reply is currently being created |
-| `.reaction-box` | Contains a reaction image and the count |
-| `.reacted` | Additional class for reaction-box when the user has reacted with a particular reaction |
-| `.reaction-count` | Contains the count for reaction |
-| `.completer` | Container for the message completer |
-| `.completer-entry` | Container for a single entry in the completer |
-| `.completer-entry-label` | Contains the label for an entry in the completer |
-| `.completer-entry-image` | Contains the image for an entry in the completer |
-| `.embed` | Container for a message embed |
-| `.embed-author` | The author of an embed |
-| `.embed-title` | The title of an embed |
-| `.embed-description` | The description of an embed |
-| `.embed-field-title` | The title of an embed field |
-| `.embed-field-value` | The value of an embed field |
-| `.embed-footer` | The footer of an embed |
-| `.members` | Container of the member list |
-| `.members-row` | All rows within the members container |
-| `.members-row-label` | All labels in the members container |
-| `.members-row-member` | Rows containing a member |
-| `.members-row-role` | Rows containing a role |
-| `.members-row-avatar` | Contains the avatar for a row in the member list |
-| `.status-indicator` | The status indicator |
-| `.online` | Applied to status indicators when the associated user is online |
-| `.idle` | Applied to status indicators when the associated user is away |
-| `.dnd` | Applied to status indicators when the associated user is on do not disturb |
-| `.offline` | Applied to status indicators when the associated user is offline |
-| `.typing-indicator` | The typing indicator (also used for replies) |
+| Selector                       | Description                                                                                       |
+|--------------------------------|---------------------------------------------------------------------------------------------------|
+| `.app-window`                  | Applied to all windows. This means the main window and all popups                                 |
+| `.app-popup`                   | Additional class for `.app-window`s when the window is not the main window                        |
+| `.channel-list`                | Container of the channel list                                                                     |
+| `.messages`                    | Container of user messages                                                                        |
+| `.message-container`           | The container which holds a user's messages                                                       |
+| `.message-container-author`    | The author label for a message container                                                          |
+| `.message-container-timestamp` | The timestamp label for a message container                                                       |
+| `.message-container-avatar`    | Avatar for a user in a message                                                                    |
+| `.message-container-extra`     | Label containing BOT/Webhook                                                                      |
+| `.message-text`                | The text of a user message                                                                        |
+| `.pending`                     | Extra class of .message-text for messages pending to be sent                                      |
+| `.failed`                      | Extra class of .message-text for messages that failed to be sent                                  |
+| `.message-attachment-box`      | Contains attachment info                                                                          |
+| `.message-reply`               | Container for the replied-to message in a reply (these elements will also have .message-text set) |
+| `.message-input`               | Applied to the chat input container                                                               |
+| `.replying`                    | Extra class for chat input container when a reply is currently being created                      |
+| `.reaction-box`                | Contains a reaction image and the count                                                           |
+| `.reacted`                     | Additional class for reaction-box when the user has reacted with a particular reaction            |
+| `.reaction-count`              | Contains the count for reaction                                                                   |
+| `.completer`                   | Container for the message completer                                                               |
+| `.completer-entry`             | Container for a single entry in the completer                                                     |
+| `.completer-entry-label`       | Contains the label for an entry in the completer                                                  |
+| `.completer-entry-image`       | Contains the image for an entry in the completer                                                  |
+| `.embed`                       | Container for a message embed                                                                     |
+| `.embed-author`                | The author of an embed                                                                            |
+| `.embed-title`                 | The title of an embed                                                                             |
+| `.embed-description`           | The description of an embed                                                                       |
+| `.embed-field-title`           | The title of an embed field                                                                       |
+| `.embed-field-value`           | The value of an embed field                                                                       |
+| `.embed-footer`                | The footer of an embed                                                                            |
+| `.members`                     | Container of the member list                                                                      |
+| `.members-row`                 | All rows within the members container                                                             |
+| `.members-row-label`           | All labels in the members container                                                               |
+| `.members-row-member`          | Rows containing a member                                                                          |
+| `.members-row-role`            | Rows containing a role                                                                            |
+| `.members-row-avatar`          | Contains the avatar for a row in the member list                                                  |
+| `.status-indicator`            | The status indicator                                                                              |
+| `.online`                      | Applied to status indicators when the associated user is online                                   |
+| `.idle`                        | Applied to status indicators when the associated user is away                                     |
+| `.dnd`                         | Applied to status indicators when the associated user is on do not disturb                        |
+| `.offline`                     | Applied to status indicators when the associated user is offline                                  |
+| `.typing-indicator`            | The typing indicator (also used for replies)                                                      |
 
 Used in reorderable list implementation:
 | Selector             |
-| -------------------- |
+|----------------------|
 | `.drag-icon`         |
 | `.drag-hover-top`    |
 | `.drag-hover-bottom` |
 
 Used in guild settings popup:
 
-| Selector    | Description |
-| ----------- | ----------- |
+| Selector                                            | Description                                       |
+|-----------------------------------------------------|---------------------------------------------------|
 | `.guild-settings-window` `.guild-members-pane-list` | Container for list of members in the members pane |
-| `.guild-members-pane-info` | Container for member info |
-| `.guild-roles-pane-list` | Container for list of roles in the roles pane |
+| `.guild-members-pane-info`                          | Container for member info                         |
+| `.guild-roles-pane-list`                            | Container for list of roles in the roles pane     |
 
 Used in profile popup:
 
-| Selector    | Description |
-| ----------- | ----------- |
-| `.mutual-friend-item` | Applied to every item in the mutual friends list |
-| `.mutual-friend-item-name` | Name in mutual friend item |
-| `.mutual-friend-item-avatar` | Avatar in mutual friend item |
-| `.mutual-guild-item` | Applied to every item in the mutual guilds list |
-| `.mutual-guild-item-name` | Name in mutual guild item |
-| `.mutual-guild-item-icon` | Icon in mutual guild item |
-| `.mutual-guild-item-nick` | User nickname in mutual guild item |
-| `.profile-connection` | Applied to every item in the user connections list |
-| `.profile-connection-label` | Label in profile connection item |
-| `.profile-connection-check` | Checkmark in verified profile connection items |
-| `.profile-connections` | Container for profile connections |
-| `.profile-notes` | Container for notes in profile window |
-| `.profile-notes-label` | Label that says "NOTE" |
-| `.profile-notes-text` | Actual note text |
-| `.profile-info-pane` | Applied to container for info section of profile popup |
-| `.profile-info-created` | Label for creation date of profile |
-| `.user-profile-window` | |
-| `.profile-main-container` | Inner container for profile |
-| `.profile-avatar` | |
-| `.profile-username` | |
-| `.profile-switcher` | Buttons used to switch viewed section of profile |
-| `.profile-stack` | Container for profile info that can be switched between |
-| `.profile-badges` `.profile-badge` | Container for badges |
+| Selector                           | Description                                             |
+|------------------------------------|---------------------------------------------------------|
+| `.mutual-friend-item`              | Applied to every item in the mutual friends list        |
+| `.mutual-friend-item-name`         | Name in mutual friend item                              |
+| `.mutual-friend-item-avatar`       | Avatar in mutual friend item                            |
+| `.mutual-guild-item`               | Applied to every item in the mutual guilds list         |
+| `.mutual-guild-item-name`          | Name in mutual guild item                               |
+| `.mutual-guild-item-icon`          | Icon in mutual guild item                               |
+| `.mutual-guild-item-nick`          | User nickname in mutual guild item                      |
+| `.profile-connection`              | Applied to every item in the user connections list      |
+| `.profile-connection-label`        | Label in profile connection item                        |
+| `.profile-connection-check`        | Checkmark in verified profile connection items          |
+| `.profile-connections`             | Container for profile connections                       |
+| `.profile-notes`                   | Container for notes in profile window                   |
+| `.profile-notes-label`             | Label that says "NOTE"                                  |
+| `.profile-notes-text`              | Actual note text                                        |
+| `.profile-info-pane`               | Applied to container for info section of profile popup  |
+| `.profile-info-created`            | Label for creation date of profile                      |
+| `.user-profile-window`             |                                                         |
+| `.profile-main-container`          | Inner container for profile                             |
+| `.profile-avatar`                  |                                                         |
+| `.profile-username`                |                                                         |
+| `.profile-switcher`                | Buttons used to switch viewed section of profile        |
+| `.profile-stack`                   | Container for profile info that can be switched between |
+| `.profile-badges` `.profile-badge` | Container for badges                                    |
 
 ### Settings
 
@@ -237,53 +237,53 @@ For example, memory_db would be set by adding `memory_db = true` under the line 
 
 #### discord
 
-| Setting     | Type        | Default     | Description |
-| ----------- | ----------- | ----------- | ----------- |
-| `gateway` | string | | override url for Discord gateway. must be json format and use zlib stream compression |
-| `api_base` | string | | override base url for Discord API |
-| `memory_db` | boolean | false | if true, Discord data will be kept in memory as opposed to on disk |
-| `token` | string | |  Discord token used to login, this can be set from the menu |
-| `prefetch` | boolean | false | if true, new messages will cause the avatar and image attachments to be automatically downloaded |
-| `autoconnect` | boolean | false | autoconnect to discord |
+| Setting       | Type    | Default | Description                                                                                      |
+|---------------|---------|---------|--------------------------------------------------------------------------------------------------|
+| `gateway`     | string  |         | override url for Discord gateway. must be json format and use zlib stream compression            |
+| `api_base`    | string  |         | override base url for Discord API                                                                |
+| `memory_db`   | boolean | false   | if true, Discord data will be kept in memory as opposed to on disk                               |
+| `token`       | string  |         | Discord token used to login, this can be set from the menu                                       |
+| `prefetch`    | boolean | false   | if true, new messages will cause the avatar and image attachments to be automatically downloaded |
+| `autoconnect` | boolean | false   | autoconnect to discord                                                                           |
 
 #### http
 
-| Setting     | Type        | Default     | Description |
-| ----------- | ----------- | ----------- | ----------- |
-| `user_agent` | string | | sets the user-agent to use in HTTP requests to the Discord API (not including media/images) |
-| `concurrent` | int | 20 | how many images can be concurrently retrieved |
+| Setting      | Type   | Default | Description                                                                                 |
+|--------------|--------|---------|---------------------------------------------------------------------------------------------|
+| `user_agent` | string |         | sets the user-agent to use in HTTP requests to the Discord API (not including media/images) |
+| `concurrent` | int    | 20      | how many images can be concurrently retrieved                                               |
 
 #### gui
 
-| Setting     | Type        | Default     | Description |
-| ----------- | ----------- | ----------- | ----------- |
-| `member_list_discriminator` | boolean | true | show user discriminators in the member list |
-| `stock_emojis` | boolean | true | allow abaddon to substitute unicode emojis with images from emojis.bin, must be false to allow GTK to render emojis itself |
-| `custom_emojis` | boolean | true | download and use custom Discord emojis |
-| `css` | string | | path to the main CSS file |
-| `animations` | boolean | true | use animated images where available (e.g. server icons, emojis, avatars). false means static images will be used |
-| `animated_guild_hover_only` | boolean | true | only animate guild icons when the guild is being hovered over |
-| `owner_crown` | boolean | true | show a crown next to the owner |
-| `unreads` | boolean | true | show unread indicators and mention badges |
-| `save_state` | boolean | true | save the state of the gui (active channels, tabs, expanded channels) |
-| `alt_menu` | boolean | false | keep the menu hidden unless revealed with alt key |
-| `hide_to_tray` | boolean | false | hide abaddon to the system tray on window close |
+| Setting                     | Type    | Default | Description                                                                                                                |
+|-----------------------------|---------|---------|----------------------------------------------------------------------------------------------------------------------------|
+| `member_list_discriminator` | boolean | true    | show user discriminators in the member list                                                                                |
+| `stock_emojis`              | boolean | true    | allow abaddon to substitute unicode emojis with images from emojis.bin, must be false to allow GTK to render emojis itself |
+| `custom_emojis`             | boolean | true    | download and use custom Discord emojis                                                                                     |
+| `css`                       | string  |         | path to the main CSS file                                                                                                  |
+| `animations`                | boolean | true    | use animated images where available (e.g. server icons, emojis, avatars). false means static images will be used           |
+| `animated_guild_hover_only` | boolean | true    | only animate guild icons when the guild is being hovered over                                                              |
+| `owner_crown`               | boolean | true    | show a crown next to the owner                                                                                             |
+| `unreads`                   | boolean | true    | show unread indicators and mention badges                                                                                  |
+| `save_state`                | boolean | true    | save the state of the gui (active channels, tabs, expanded channels)                                                       |
+| `alt_menu`                  | boolean | false   | keep the menu hidden unless revealed with alt key                                                                          |
+| `hide_to_tray`              | boolean | false   | hide abaddon to the system tray on window close                                                                            |
 
 #### style
 
-| Setting     | Type        | Default     | Description |
-| ----------- | ----------- | ----------- | ----------- |
-| `linkcolor` | string | | color to use for links in messages |
-| `expandercolor` | string | | color to use for the expander in the channel list |
-| `nsfwchannelcolor` | string | | color to use for NSFW channels in the channel list |
-| `channelcolor` | string | | color to use for SFW channels in the channel list |
-| `mentionbadgecolor` | string | | background color for mention badges |
-| `mentionbadgetextcolor` | string | | color to use for number displayed on mention badges |
-| `unreadcolor` | string | | color to use for the unread indicator |
+| Setting                 | Type   | Description                                         |
+|-------------------------|--------|-----------------------------------------------------|
+| `linkcolor`             | string | color to use for links in messages                  |
+| `expandercolor`         | string | color to use for the expander in the channel list   |
+| `nsfwchannelcolor`      | string | color to use for NSFW channels in the channel list  |
+| `channelcolor`          | string | color to use for SFW channels in the channel list   |
+| `mentionbadgecolor`     | string | background color for mention badges                 |
+| `mentionbadgetextcolor` | string | color to use for number displayed on mention badges |
+| `unreadcolor`           | string | color to use for the unread indicator               |
 
 ### Environment variables
 
-| variable    | Description |
-| ----------- | ----------- |
-| `ABADDON_NO_FC` | (Windows only) don't use custom font config |
+| variable         | Description                                                                  |
+|------------------|------------------------------------------------------------------------------|
+| `ABADDON_NO_FC`  | (Windows only) don't use custom font config                                  |
 | `ABADDON_CONFIG` | change path of configuration file to use. relative to cwd or can be absolute |

--- a/README.md
+++ b/README.md
@@ -135,90 +135,93 @@ spam filter's wrath:
 
 #### CSS selectors
 
-**`.app-window`** - Applied to all windows. This means the main window and all popups
-**`.app-popup`** - Additional class for `.app-window`s when the window is not the main window
-
-**`.channel-list`** - Container of the channel list
-
-**`.messages`** - Container of user messages
-**`.message-container`** - The container which holds a user's messages
-**`.message-container-author`** - The author label for a message container
-**`.message-container-timestamp`** - The timestamp label for a message container
-**`.message-container-avatar`** - Avatar for a user in a message
-**`.message-container-extra`** - Label containing BOT/Webhook
-**`.message-text`** - The text of a user message
-**`.pending`** - Extra class of .message-text for messages pending to be sent
-**`.failed`** - Extra class of .message-text for messages that failed to be sent
-**`.message-attachment-box`** - Contains attachment info
-**`.message-reply`** - Container for the replied-to message in a reply (these elements will also have .message-text set)
-**`.message-input`** - Applied to the chat input container
-**`.replying`** - Extra class for chat input container when a reply is currently being created
-**`.reaction-box`** - Contains a reaction image and the count
-**`.reacted`** - Additional class for reaction-box when the user has reacted with a particular reaction
-**`.reaction-count`** - Contains the count for reaction
-
-**`.completer`** - Container for the message completer
-**`.completer-entry`** - Container for a single entry in the completer
-**`.completer-entry-label`** - Contains the label for an entry in the completer
-**`.completer-entry-image`** - Contains the image for an entry in the completer
-
-**`.embed`** - Container for a message embed
-**`.embed-author`** - The author of an embed
-**`.embed-title`** - The title of an embed
-**`.embed-description`** - The description of an embed
-**`.embed-field-title`** - The title of an embed field
-**`.embed-field-value`** - The value of an embed field
-**`.embed-footer`** - The footer of an embed
-
-**`.members`** - Container of the member list
-**`.members-row`** - All rows within the members container
-**`.members-row-label`** - All labels in the members container
-**`.members-row-member`** - Rows containing a member
-**`.members-row-role`** - Rows containing a role
-**`.members-row-avatar`** - Contains the avatar for a row in the member list
-
-**`.status-indicator`** - The status indicator
-**`.online`** - Applied to status indicators when the associated user is online
-**`.idle`** - Applied to status indicators when the associated user is away
-**`.dnd`** - Applied to status indicators when the associated user is on do not disturb
-**`.offline`** - Applied to status indicators when the associated user is offline
-
-**`.typing-indicator`** - The typing indicator (also used for replies)
+| Selector    | Description |
+| ----------- | ----------- |
+| `.app-window` | Applied to all windows. This means the main window and all popups |
+| `.app-popup`   | Additional class for `.app-window`s when the window is not the main window |
+| `.channel-list`   | Container of the channel list |
+| `.messages` | Container of user messages |
+| `.message-container` | The container which holds a user's messages |
+| `.message-container-author` | The author label for a message container |
+| `.message-container-timestamp` | The timestamp label for a message container |
+| `.message-container-avatar` | Avatar for a user in a message |
+| `.message-container-extra` | Label containing BOT/Webhook |
+| `.message-text` | The text of a user message |
+| `.pending` | Extra class of .message-text for messages pending to be sent |
+| `.failed` | Extra class of .message-text for messages that failed to be sent |
+| `.message-attachment-box` | Contains attachment info |
+| `.message-reply` | Container for the replied-to message in a reply (these elements will also have .message-text set) |
+| `.message-input` | Applied to the chat input container |
+| `.replying` | Extra class for chat input container when a reply is currently being created |
+| `.reaction-box` | Contains a reaction image and the count |
+| `.reacted` | Additional class for reaction-box when the user has reacted with a particular reaction |
+| `.reaction-count` | Contains the count for reaction |
+| `.completer` | Container for the message completer |
+| `.completer-entry` | Container for a single entry in the completer |
+| `.completer-entry-label` | Contains the label for an entry in the completer |
+| `.completer-entry-image` | Contains the image for an entry in the completer |
+| `.embed` | Container for a message embed |
+| `.embed-author` | The author of an embed |
+| `.embed-title` | The title of an embed |
+| `.embed-description` | The description of an embed |
+| `.embed-field-title` | The title of an embed field |
+| `.embed-field-value` | The value of an embed field |
+| `.embed-footer` | The footer of an embed |
+| `.members` | Container of the member list |
+| `.members-row` | All rows within the members container |
+| `.members-row-label` | All labels in the members container |
+| `.members-row-member` | Rows containing a member |
+| `.members-row-role` | Rows containing a role |
+| `.members-row-avatar` | Contains the avatar for a row in the member list |
+| `.status-indicator` | The status indicator |
+| `.online` | Applied to status indicators when the associated user is online |
+| `.idle` | Applied to status indicators when the associated user is away |
+| `.dnd` | Applied to status indicators when the associated user is on do not disturb |
+| `.offline` | Applied to status indicators when the associated user is offline |
+| `.typing-indicator` | The typing indicator (also used for replies) |
 
 Used in reorderable list implementation:
-**`.drag-icon`** **`.drag-hover-top`** **`.drag-hover-bottom`**
+| Selector             |
+| -------------------- |
+| `.drag-icon`         |
+| `.drag-hover-top`    |
+| `.drag-hover-bottom` |
 
 Used in guild settings popup:
-**`.guild-settings-window`**
-**`.guild-members-pane-list`** - Container for list of members in the members pane
-**`.guild-members-pane-info`** - Container for member info
-**`.guild-roles-pane-list`** - Container for list of roles in the roles pane
+
+| Selector    | Description |
+| ----------- | ----------- |
+| `.guild-settings-window` `.guild-members-pane-list` | Container for list of members in the members pane |
+| `.guild-members-pane-info` | Container for member info |
+| `.guild-roles-pane-list` | Container for list of roles in the roles pane |
 
 Used in profile popup:
-**`.mutual-friend-item`** - Applied to every item in the mutual friends list
-**`.mutual-friend-item-name`** - Name in mutual friend item
-**`.mutual-friend-item-avatar`** - Avatar in mutual friend item
-**`.mutual-guild-item`** - Applied to every item in the mutual guilds list
-**`.mutual-guild-item-name`** - Name in mutual guild item
-**`.mutual-guild-item-icon`** - Icon in mutual guild item
-**`.mutual-guild-item-nick`** - User nickname in mutual guild item
-**`.profile-connection`** - Applied to every item in the user connections list
-**`.profile-connection-label`** - Label in profile connection item
-**`.profile-connection-check`** - Checkmark in verified profile connection items
-**`.profile-connections`** - Container for profile connections
-**`.profile-notes`** - Container for notes in profile window
-**`.profile-notes-label`** - Label that says "NOTE"
-**`.profile-notes-text`** - Actual note text
-**`.profile-info-pane`** - Applied to container for info section of profile popup
-**`.profile-info-created`** - Label for creation date of profile
-**`.user-profile-window`**
-**`.profile-main-container`** - Inner container for profile
-**`.profile-avatar`**
-**`.profile-username`**
-**`.profile-switcher`** - Buttons used to switch viewed section of profile
-**`.profile-stack`** - Container for profile info that can be switched between
-**`.profile-badges`** - Container for badges
-**`.profile-badge`**
+
+| Selector    | Description |
+| ----------- | ----------- |
+| `.mutual-friend-item` | Applied to every item in the mutual friends list |
+| `.mutual-friend-item-name` | Name in mutual friend item |
+| `.mutual-friend-item-avatar` | Avatar in mutual friend item |
+| `.mutual-guild-item` | Applied to every item in the mutual guilds list |
+| `.mutual-guild-item-name` | Name in mutual guild item |
+| `.mutual-guild-item-icon` | Icon in mutual guild item |
+| `.mutual-guild-item-nick` | User nickname in mutual guild item |
+| `.profile-connection` | Applied to every item in the user connections list |
+| `.profile-connection-label` | Label in profile connection item |
+| `.profile-connection-check` | Checkmark in verified profile connection items |
+| `.profile-connections` | Container for profile connections |
+| `.profile-notes` | Container for notes in profile window |
+| `.profile-notes-label` | Label that says "NOTE" |
+| `.profile-notes-text` | Actual note text |
+| `.profile-info-pane` | Applied to container for info section of profile popup |
+| `.profile-info-created` | Label for creation date of profile |
+| `.user-profile-window` | |
+| `.profile-main-container` | Inner container for profile |
+| `.profile-avatar` | |
+| `.profile-username` | |
+| `.profile-switcher` | Buttons used to switch viewed section of profile |
+| `.profile-stack` | Container for profile info that can be switched between |
+| `.profile-badges` `.profile-badge` | Container for badges |
 
 ### Settings
 

--- a/README.md
+++ b/README.md
@@ -237,47 +237,53 @@ For example, memory_db would be set by adding `memory_db = true` under the line 
 
 #### discord
 
-* **`gateway`** (string) - override url for Discord gateway. must be json format and use zlib stream compression
-* **`api_base`** (string) - override base url for Discord API
-* **`memory_db`** (true or false, `default: false`) - if true, Discord data will be kept in memory as opposed to on disk
-* **`token`** (string) - Discord token used to login, this can be set from the menu
-* **`prefetch`** (true or false, `default: false`) - if true, new messages will cause the avatar and image attachments to be
-  automatically downloaded
-* **`autoconnect`** (true or false, `default: false`) - autoconnect to discord
+| Setting     | Type        | Default     | Description |
+| ----------- | ----------- | ----------- | ----------- |
+| `gateway` | string | | override url for Discord gateway. must be json format and use zlib stream compression |
+| `api_base` | string | | override base url for Discord API |
+| `memory_db` | boolean | false | if true, Discord data will be kept in memory as opposed to on disk |
+| `token` | string | |  Discord token used to login, this can be set from the menu |
+| `prefetch` | boolean | false | if true, new messages will cause the avatar and image attachments to be automatically downloaded |
+| `autoconnect` | boolean | false | autoconnect to discord |
 
 #### http
 
-* **`user_agent`** (string) - sets the user-agent to use in HTTP requests to the Discord API (not including media/images)
-* **`concurrent`** (int, `default: 20`) - how many images can be concurrently retrieved
+| Setting     | Type        | Default     | Description |
+| ----------- | ----------- | ----------- | ----------- |
+| `user_agent` | string | | sets the user-agent to use in HTTP requests to the Discord API (not including media/images) |
+| `concurrent` | int | 20 | how many images can be concurrently retrieved |
 
 #### gui
 
-* **`member_list_discriminator`** (true or false, `default: true`) - show user discriminators in the member list
-* **`stock_emojis`** (true or false, `default: true`) - allow abaddon to substitute unicode emojis with images from emojis.bin,
-  must be false to allow GTK to render emojis itself
-* **`custom_emojis`** (true or false, `default: true`) - download and use custom Discord emojis
-* **`css`** (string) - path to the main CSS file
-* **`animations`** (true or false, `default: true`) - use animated images where available (e.g. server icons, emojis, avatars).
-  false means static images will be used
-* **`animated_guild_hover_only`** (true or false, `default: true`) - only animate guild icons when the guild is being hovered
-  over
-* **`owner_crown`** (true or false, `default: true`) - show a crown next to the owner
-* **`unreads`** (true or false, `default: true`) - show unread indicators and mention badges
-* **`save_state`** (true or false, `default: true`) - save the state of the gui (active channels, tabs, expanded channels)
-* **`alt_menu`** (true or false, `default: false`) - keep the menu hidden unless revealed with alt key
-* **`hide_to_tray`** (true or false, `default: false`) - hide abaddon to the system tray on window close
+| Setting     | Type        | Default     | Description |
+| ----------- | ----------- | ----------- | ----------- |
+| `member_list_discriminator` | boolean | true | show user discriminators in the member list |
+| `stock_emojis` | boolean | true | allow abaddon to substitute unicode emojis with images from emojis.bin, must be false to allow GTK to render emojis itself |
+| `custom_emojis` | boolean | true | download and use custom Discord emojis |
+| `css` | string | | path to the main CSS file |
+| `animations` | boolean | true | use animated images where available (e.g. server icons, emojis, avatars). false means static images will be used |
+| `animated_guild_hover_only` | boolean | true | only animate guild icons when the guild is being hovered over |
+| `owner_crown` | boolean | true | show a crown next to the owner |
+| `unreads` | boolean | true | show unread indicators and mention badges |
+| `save_state` | boolean | true | save the state of the gui (active channels, tabs, expanded channels) |
+| `alt_menu` | boolean | false | keep the menu hidden unless revealed with alt key |
+| `hide_to_tray` | boolean | false | hide abaddon to the system tray on window close |
 
 #### style
 
-* **`linkcolor`** (string) - color to use for links in messages
-* **`expandercolor`** (string) - color to use for the expander in the channel list
-* **`nsfwchannelcolor`** (string) - color to use for NSFW channels in the channel list
-* **`channelcolor`** (string) - color to use for SFW channels in the channel list
-* **`mentionbadgecolor`** (string) - background color for mention badges
-* **`mentionbadgetextcolor`** (string) - color to use for number displayed on mention badges
-* **`unreadcolor`** (string) - color to use for the unread indicator
+| Setting     | Type        | Default     | Description |
+| ----------- | ----------- | ----------- | ----------- |
+| `linkcolor` | string | | color to use for links in messages |
+| `expandercolor` | string | | color to use for the expander in the channel list |
+| `nsfwchannelcolor` | string | | color to use for NSFW channels in the channel list |
+| `channelcolor` | string | | color to use for SFW channels in the channel list |
+| `mentionbadgecolor` | string | | background color for mention badges |
+| `mentionbadgetextcolor` | string | | color to use for number displayed on mention badges |
+| `unreadcolor` | string | | color to use for the unread indicator |
 
 ### Environment variables
 
-* **`ABADDON_NO_FC`** (Windows only) - don't use custom font config
-* **`ABADDON_CONFIG`** - change path of configuration file to use. relative to cwd or can be absolute
+| variable    | Description |
+| ----------- | ----------- |
+| `ABADDON_NO_FC` | (Windows only) don't use custom font config |
+| `ABADDON_CONFIG` | change path of configuration file to use. relative to cwd or can be absolute |


### PR DESCRIPTION
markdown table formatter used: http://markdowntable.com/