### PR TITLE
docs: Fix Fedora's install deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ the result of fundamental issues with Discord's thread implementation.
       ```
     * On Fedora Linux:
       ```Shell
-      $ sudo dnf install g++ cmake gtkmm3.0-devel libcurl-devel sqlite-devel openssl-devel json-devel libsecret-devel libhandy-devel
+      $ sudo dnf install g++ cmake gtkmm30-devel.x86_64 libcurl-devel sqlite-devel openssl-devel json-devel libsecret-devel libhandy-devel
       ```
 2. `git clone https://github.com/uowuo/abaddon --recurse-submodules="subprojects" && cd abaddon`
 3. `mkdir build && cd build`


### PR DESCRIPTION
Dependencies that were added by this PR: https://github.com/uowuo/abaddon/pull/131 seem to contain a non-existing dependency `gtkmm3.0-devel`. The correct package name is `gtkmm30-devel.x86_64` for x86. You can see deps for other architectures by running `dnf search gtkmm3`

```
No match for argument: gtkmm3.0-devel
Error: Unable to find a match: gtkmm3.0-devel
```
> output of `sudo dnf install gtkmm3.0-devel`