### PR TITLE
Update attachment size limits for base users

### DIFF
--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -4,7 +4,7 @@
 constexpr static uint64_t SnowflakeSplitDifference = 600;
 constexpr static int MaxMessagesForChatCull = 50; // this has to be 50 (for now) cuz that magic number is used in a couple other places and i dont feel like replacing them
 constexpr static int AttachmentItemSize = 120;
-constexpr static int BaseAttachmentSizeLimit = 8 * 1024 * 1024;
+constexpr static int BaseAttachmentSizeLimit = 25 * 1024 * 1024;
 constexpr static int NitroClassicAttachmentSizeLimit = 50 * 1024 * 1024;
 constexpr static int NitroAttachmentSizeLimit = 100 * 1024 * 1024;
 constexpr static int BoostLevel2AttachmentSizeLimit = 50 * 1024 * 1024;


### PR DESCRIPTION
Just noticed that constants.hpp had old attachment size limits for base and nitro users. It should be fine now I think.