### PR TITLE
Show unread indicators next to categories containing unread channels

### DIFF
--- a/src/components/channels.hpp
+++ b/src/components/channels.hpp
@@ -116,9 +116,10 @@ protected:
     void UpdateCreateDMChannel(const ChannelData &channel);
     void SetDMChannelIcon(Gtk::TreeIter iter, const ChannelData &dm);
 
+    void RedrawUnreadIndicatorsForChannel(const ChannelData& channel);
     void OnMessageAck(const MessageAckData &data);
-
     void OnMessageCreate(const Message &msg);
+
     Gtk::TreeModel::Path m_path_for_menu;
 
     // cant be recovered through selection

--- a/src/discord/discord.cpp
+++ b/src/discord/discord.cpp
@@ -1317,6 +1317,16 @@ int DiscordClient::GetUnreadStateForChannel(Snowflake id) const noexcept {
     return iter->second;
 }
 
+int DiscordClient::GetUnreadChannelsCountForCategory(Snowflake id) const noexcept {
+    int result = 0;
+    for (Snowflake channel_id : m_store.GetChannelIDsWithParentID(id)) {
+        const auto iter = m_unread.find(channel_id);
+        if (iter == m_unread.end()) continue;
+        result += 1;
+    }
+    return result;
+}
+
 bool DiscordClient::GetUnreadStateForGuild(Snowflake id, int &total_mentions) const noexcept {
     total_mentions = 0;
     bool has_any_unread = false;

--- a/src/discord/discord.cpp
+++ b/src/discord/discord.cpp
@@ -1320,6 +1320,7 @@ int DiscordClient::GetUnreadStateForChannel(Snowflake id) const noexcept {
 int DiscordClient::GetUnreadChannelsCountForCategory(Snowflake id) const noexcept {
     int result = 0;
     for (Snowflake channel_id : m_store.GetChannelIDsWithParentID(id)) {
+        if (IsChannelMuted(channel_id)) continue;
         const auto iter = m_unread.find(channel_id);
         if (iter == m_unread.end()) continue;
         result += 1;

--- a/src/discord/discord.hpp
+++ b/src/discord/discord.hpp
@@ -214,6 +214,7 @@ public:
     bool IsChannelMuted(Snowflake id) const noexcept;
     bool IsGuildMuted(Snowflake id) const noexcept;
     int GetUnreadStateForChannel(Snowflake id) const noexcept;
+    int GetUnreadChannelsCountForCategory(Snowflake id) const noexcept;
     bool GetUnreadStateForGuild(Snowflake id, int &total_mentions) const noexcept;
     int GetUnreadDMsCount() const;
 


### PR DESCRIPTION
Screenshot:
![image](https://github.com/uowuo/abaddon/assets/120114/9d32c8c5-ecd2-4687-b27b-4bad6d8af662)
This allows seeing at one glance which folded categories from a server have unread channels.