### PR TITLE
keep aspect ratio in LazyImage

### DIFF
--- a/src/components/lazyimage.cpp
+++ b/src/components/lazyimage.cpp
@@ -39,7 +39,9 @@ bool LazyImage::OnDraw(const Cairo::RefPtr<Cairo::Context> &context) {
         Abaddon::Get().GetImageManager().LoadAnimationFromURL(m_url, m_width, m_height, sigc::track_obj(cb, *this));
     } else {
         auto cb = [this](const Glib::RefPtr<Gdk::Pixbuf> &pb) {
-            property_pixbuf() = pb->scale_simple(m_width, m_height, Gdk::INTERP_BILINEAR);
+            int cw, ch;
+        	GetImageDimensions(pb->get_width(), pb->get_height(), cw, ch, m_width, m_height);
+            property_pixbuf() = pb->scale_simple(cw, ch, Gdk::INTERP_BILINEAR);
         };
 
         Abaddon::Get().GetImageManager().LoadFromURL(m_url, sigc::track_obj(cb, *this));


### PR DESCRIPTION
This PR hopefully fixes all stretched stickers and stretched emojis in message reactions

## stickers
Before:
![image](https://github.com/uowuo/abaddon/assets/13377926/ddb8861f-d07e-451b-a77c-bd3bbf45fb15)

After:
![image](https://github.com/uowuo/abaddon/assets/13377926/6e279e28-c467-4281-9b78-637eb6d7e4a5)


## emojis in message reactions
Before:
![image](https://github.com/uowuo/abaddon/assets/13377926/a0453417-767e-43d4-9339-cd7f45276954)

After:
![](https://cdn.discordapp.com/attachments/363965764987912194/1132011765572571256/unknown.png)
