### PR TITLE
Copy resources into build directory for MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,11 @@ target_include_directories(abaddon PUBLIC ${ZLIB_INCLUDE_DIRS})
 target_include_directories(abaddon PUBLIC ${SQLite3_INCLUDE_DIRS})
 target_include_directories(abaddon PUBLIC ${NLOHMANN_JSON_INCLUDE_DIRS})
 
+if(APPLE)
+    # Copy res directory to build directory
+    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/res/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR} FILES_MATCHING PATTERN "*")
+endif()
+
 if (ENABLE_QRCODE_LOGIN)
     add_library(qrcodegen subprojects/qrcodegen/cpp/qrcodegen.hpp subprojects/qrcodegen/cpp/qrcodegen.cpp)
     target_include_directories(qrcodegen PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/subprojects/qrcodegen/cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,13 +63,10 @@ target_include_directories(abaddon PUBLIC ${SQLite3_INCLUDE_DIRS})
 target_include_directories(abaddon PUBLIC ${NLOHMANN_JSON_INCLUDE_DIRS})
 
 if(APPLE)
-    file(GLOB RES_SUBDIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/res/*)
-    foreach(RES_SUBDIRECTORY ${RES_SUBDIRECTORIES})
-        if(IS_DIRECTORY ${RES_SUBDIRECTORY})
-            get_filename_component(RES_SUBDIRECTORY_NAME ${RES_SUBDIRECTORY} NAME)
-            install(DIRECTORY ${RES_SUBDIRECTORY} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${RES_SUBDIRECTORY_NAME})
-        endif()
-    endforeach()
+    install(
+        DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/res/css ${CMAKE_CURRENT_SOURCE_DIR}/res/fonts ${CMAKE_CURRENT_SOURCE_DIR}/res/res
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${RES_SUBDIRECTORY_NAME}
+    )
 endif()
 
 if (ENABLE_QRCODE_LOGIN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,13 @@ target_include_directories(abaddon PUBLIC ${SQLite3_INCLUDE_DIRS})
 target_include_directories(abaddon PUBLIC ${NLOHMANN_JSON_INCLUDE_DIRS})
 
 if(APPLE)
-    # Copy res directory to build directory
-    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/res/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR} FILES_MATCHING PATTERN "*")
+    file(GLOB RES_SUBDIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/res/*)
+    foreach(RES_SUBDIRECTORY ${RES_SUBDIRECTORIES})
+        if(IS_DIRECTORY ${RES_SUBDIRECTORY})
+            get_filename_component(RES_SUBDIRECTORY_NAME ${RES_SUBDIRECTORY} NAME)
+            install(DIRECTORY ${RES_SUBDIRECTORY} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${RES_SUBDIRECTORY_NAME})
+        endif()
+    endforeach()
 endif()
 
 if (ENABLE_QRCODE_LOGIN)


### PR DESCRIPTION
Copies contents of res directory into build directory for MacOS to resolve the follow messages on launch:
- "css failed parsing (Failed to import: Error opening file /Users/REDACTED/Documents/abaddon/build/css/main.css: No such file or directory)"
- "css failed to load (<broken file>: 1:0Failed to import: Error opening file /Users/REDACTED/Documents/abaddon/build/css/main.css: No such file or directory)"
- "The emoji file couldn't be loaded!"

<img width="417" alt="Screenshot 2023-08-09 at 21 57 51" src="https://github.com/uowuo/abaddon/assets/6502571/019951e4-f7d1-46e4-971f-18e2609c75fa">
<img width="411" alt="Screenshot 2023-08-09 at 21 57 39" src="https://github.com/uowuo/abaddon/assets/6502571/79a05a42-1eae-4ca4-9505-c70ba6e70aa5">
