### PR TITLE
add hackish macOS detection for home folder, resources and cache

### DIFF
--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -103,7 +103,7 @@ std::string Platform::FindResourceFolder() {
         }
     }
 
-    puts("cant find a resources folder, will try to load from cwd");
+    spdlog::get("discord")->warn("cant find a resources folder, will try to load from cwd");
     found_path = ".";
     found = true;
     return found_path;
@@ -133,7 +133,7 @@ std::string Platform::FindConfigFile() {
     }
 
     // fallback to cwd if cant find + cant make in ~/.config
-    puts("can't find configuration file!");
+    spdlog::get("discord")->warn("can't find configuration file!");
     return "./abaddon.ini";
 }
 
@@ -147,13 +147,13 @@ std::string Platform::FindStateCacheFolder() {
         if (util::IsFolder(home_path))
             return home_path;
     }
-    puts("can't find cache folder!");
+    spdlog::get("discord")->warn("can't find cache folder!");
     return ".";
 }
 
 #else
 std::string Platform::FindResourceFolder() {
-    puts("unknown OS, trying to load resources from cwd");
+    spdlog::get("discord")->warn("unknown OS, trying to load resources from cwd");
     return ".";
 }
 
@@ -161,12 +161,12 @@ std::string Platform::FindConfigFile() {
     const auto x = std::getenv("ABADDON_CONFIG");
     if (x != nullptr)
         return x;
-    puts("unknown OS, trying to load config from cwd");
+    spdlog::get("discord")->warn("unknown OS, trying to load config from cwd");
     return "./abaddon.ini";
 }
 
 std::string Platform::FindStateCacheFolder() {
-    puts("unknown OS, setting state cache folder to cwd");
+    spdlog::get("discord")->warn("unknown OS, setting state cache folder to cwd");
     return ".";
 }
 #endif


### PR DESCRIPTION
this should work just fine with #205 and it was originally intended for an [Abaddon.app (use as an example)](https://github.com/uowuo/abaddon/files/12414303/Abaddon.zip). I just still haven't found a proper way how to make the .app itself properly and also to relink libs to Contents/Frameworks instead of using them from the system brew folders.

feel free to correct my changes, feel free to help me do it properly 🙃 


EDIT: it seems like that packaging it into .app fixed notifications!!!!!!!
<img width="370" alt="image" src="https://github.com/uowuo/abaddon/assets/13377926/427046ab-108f-4da3-836c-1b3e376ff865">
<img width="370" alt="image" src="https://github.com/uowuo/abaddon/assets/13377926/7e04a4bf-fb4b-4479-8f65-5cd0a5d83a67">
<img width="370" alt="image" src="https://github.com/uowuo/abaddon/assets/13377926/90cb57f5-8d3b-4430-af0b-e3fc13bb3bbe">



EDIT 2: seems like that it also enables proper crash logs, it shows all threads and stacktraces too, that's also cool
