### PR TITLE
suggest installing adwaita-icon-theme to get icons in the client on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ the result of fundamental issues with Discord's thread implementation.
 #### Mac:
 
 1. `git clone https://github.com/uowuo/abaddon --recurse-submodules="subprojects" && cd abaddon`
-2. `brew install gtkmm3 nlohmann-json libhandy opus libsodium spdlog`
+2. `brew install gtkmm3 nlohmann-json libhandy opus libsodium spdlog adwaita-icon-theme`
 3. `mkdir build && cd build`
 4. `cmake ..`
 5. `make`


### PR DESCRIPTION
this should be redone to have:
1. icons in the resources folder rather than get those from adwaita

or 

2. package them into the .app later on and point the client to them?


or maybe it could be done differently depending on OS, I have no idea lol