### PR TITLE
disable file picker filters for macOS

### DIFF
--- a/src/components/chatinput.cpp
+++ b/src/components/chatinput.cpp
@@ -149,11 +149,6 @@ void ChatInputTextContainer::ShowFileChooser() {
         }
     });
 
-    auto filter_all = Gtk::FileFilter::create();
-    filter_all->set_name("All files (*.*)");
-    filter_all->add_pattern("*.*");
-    dlg->add_filter(filter_all);
-
     dlg->run();
 }
 


### PR DESCRIPTION
another pretty selfexplanatory change

macOS's file picker had issues with the file picker filter being enabled and it actually works just fine without it being there