### PR TITLE
set glib application name

### DIFF
--- a/src/abaddon.cpp
+++ b/src/abaddon.cpp
@@ -177,6 +177,7 @@ static void MainEventHandler(GdkEvent *event, void *main_window) {
 
 int Abaddon::StartGTK() {
     m_gtk_app = Gtk::Application::create("com.github.uowuo.abaddon");
+    Glib::set_application_name(APP_TITLE);
 
 #ifdef WITH_LIBHANDY
     m_gtk_app->signal_activate().connect([] {


### PR DESCRIPTION
my motivation for this is that the glib `application_name` gets propagated into the `app_name` field of every desktop notification presented by Abaddon. it's nice just to have something friendlier than `<unknown>` there.