### PR TITLE
Add support for miniaudio options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ file(GLOB_RECURSE ABADDON_SOURCES
         "src/*.h"
         "src/*.hpp"
         "src/*.cpp"
-        )
+)
 
 list(FILTER ABADDON_SOURCES EXCLUDE REGEX ".*notifier_gio\\.cpp$")
 list(FILTER ABADDON_SOURCES EXCLUDE REGEX ".*notifier_fallback\\.cpp$")
@@ -222,15 +222,9 @@ if (USE_MINIAUDIO)
 
     target_include_directories(abaddon PUBLIC ${MINIAUDIO_INCLUDE_DIR})
     target_compile_definitions(abaddon PRIVATE WITH_MINIAUDIO)
-
-    set(MINIAUDIO_OPTIONS "" CACHE STRING "Compiler definitions for miniaudio")
-
-    foreach (MINIAUDIO_OPTION IN LISTS MINIAUDIO_OPTIONS)
-        set_property(
-                SOURCE src/audio/ma_impl.cpp
-                APPEND
-                PROPERTY
-                COMPILE_DEFINITIONS "${MINIAUDIO_OPTION}"
-        )
-    endforeach ()
 endif ()
+
+set(ABADDON_COMPILER_DEFS "" CACHE STRING "Additional compiler definitions")
+foreach (COMPILER_DEF IN LISTS ABADDON_COMPILER_DEFS)
+    target_compile_definitions(abaddon PRIVATE "${COMPILER_DEF}")
+endforeach ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,4 +222,10 @@ if (USE_MINIAUDIO)
 
     target_include_directories(abaddon PUBLIC ${MINIAUDIO_INCLUDE_DIR})
     target_compile_definitions(abaddon PRIVATE WITH_MINIAUDIO)
+
+    set(MINIAUDIO_OPTIONS, "")
+
+    foreach (MINIAUDIO_OPTION IN LISTS MINIAUDIO_OPTIONS)
+        target_compile_definitions(abaddon PRIVATE ${MINIAUDIO_OPTION})
+    endforeach()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,9 +223,14 @@ if (USE_MINIAUDIO)
     target_include_directories(abaddon PUBLIC ${MINIAUDIO_INCLUDE_DIR})
     target_compile_definitions(abaddon PRIVATE WITH_MINIAUDIO)
 
-    set(MINIAUDIO_OPTIONS, "")
+    set(MINIAUDIO_OPTIONS "" CACHE STRING "Compiler definitions for miniaudio")
 
     foreach (MINIAUDIO_OPTION IN LISTS MINIAUDIO_OPTIONS)
-        target_compile_definitions(abaddon PRIVATE ${MINIAUDIO_OPTION})
-    endforeach()
+        set_property(
+                SOURCE src/audio/ma_impl.cpp
+                APPEND
+                PROPERTY
+                COMPILE_DEFINITIONS "${MINIAUDIO_OPTION}"
+        )
+    endforeach ()
 endif ()


### PR DESCRIPTION
Add support for miniaudio build options, through compiler definitions.
See [docs](https://miniaud.io/docs/manual/index.html#BuildOptions) for supported options.
Specifically, allows the user to choose which backends to enable/disable.

Example of a usage:
```
cmake -DCMAKE_BUILD_TYPE=Release \
-DMINIAUDIO_OPTIONS=MA_ENABLE_ONLY_SPECIFIC_BACKENDS;MA_ENABLE_NULL;MA_ENABLE_PULSEAUDIO \
..
```