### PR TITLE
Refactor audio handlng

### DIFF
--- a/src/abaddon.cpp
+++ b/src/abaddon.cpp
@@ -484,11 +484,13 @@ void Abaddon::DiscordOnThreadUpdate(const ThreadUpdateData &data) {
 
 #ifdef WITH_VOICE
 void Abaddon::OnVoiceConnected() {
+    m_audio.StartPlaybackDevice();
     m_audio.StartCaptureDevice();
     ShowVoiceWindow();
 }
 
 void Abaddon::OnVoiceDisconnected() {
+    m_audio.StopPlaybackDevice();
     m_audio.StopCaptureDevice();
     m_audio.RemoveAllSSRCs();
     if (m_voice_window != nullptr) {

--- a/src/audio/devices.cpp
+++ b/src/audio/devices.cpp
@@ -13,11 +13,11 @@ AudioDevices::AudioDevices()
     , m_capture(Gtk::ListStore::create(m_capture_columns)) {
 }
 
-Glib::RefPtr<Gtk::ListStore> AudioDevices::GetPlaybackDeviceModel() {
+Glib::RefPtr<Gtk::ListStore> AudioDevices::GetPlaybackDeviceModel() const {
     return m_playback;
 }
 
-Glib::RefPtr<Gtk::ListStore> AudioDevices::GetCaptureDeviceModel() {
+Glib::RefPtr<Gtk::ListStore> AudioDevices::GetCaptureDeviceModel() const {
     return m_capture;
 }
 
@@ -33,7 +33,7 @@ void AudioDevices::SetDevices(ma_device_info *pPlayback, ma_uint32 playback_coun
 
         if (d.isDefault) {
             m_default_playback_iter = row;
-            SetActivePlaybackDevice(row);
+            SetActivePlaybackDeviceIter(row);
         }
     }
 
@@ -48,7 +48,7 @@ void AudioDevices::SetDevices(ma_device_info *pPlayback, ma_uint32 playback_coun
 
         if (d.isDefault) {
             m_default_capture_iter = row;
-            SetActiveCaptureDevice(row);
+            SetActiveCaptureDeviceIter(row);
         }
     }
 
@@ -78,34 +78,34 @@ std::optional<ma_device_id> AudioDevices::GetCaptureDeviceIDFromModel(const Gtk:
 }
 
 std::optional<ma_device_id> AudioDevices::GetDefaultPlayback() const {
-    if (m_default_playback_iter) {
-        return static_cast<ma_device_id>((*m_default_playback_iter)[m_playback_columns.DeviceID]);
-    }
-
-    return std::nullopt;
+    return GetPlaybackDeviceIDFromModel(m_default_playback_iter);
 }
 
 std::optional<ma_device_id> AudioDevices::GetDefaultCapture() const {
-    if (m_default_capture_iter) {
-        return static_cast<ma_device_id>((*m_default_capture_iter)[m_capture_columns.DeviceID]);
-    }
-
-    return std::nullopt;
+    return GetCaptureDeviceIDFromModel(m_default_capture_iter);
 }
 
-void AudioDevices::SetActivePlaybackDevice(const Gtk::TreeModel::iterator &iter) {
+std::optional<ma_device_id> AudioDevices::GetActivePlayback() const {
+    return GetPlaybackDeviceIDFromModel(m_active_playback_iter);
+}
+
+std::optional<ma_device_id> AudioDevices::GetActiveCapture() const {
+    return GetCaptureDeviceIDFromModel(m_active_capture_iter);
+}
+
+void AudioDevices::SetActivePlaybackDeviceIter(const Gtk::TreeModel::iterator &iter) {
     m_active_playback_iter = iter;
 }
 
-void AudioDevices::SetActiveCaptureDevice(const Gtk::TreeModel::iterator &iter) {
+void AudioDevices::SetActiveCaptureDeviceIter(const Gtk::TreeModel::iterator &iter) {
     m_active_capture_iter = iter;
 }
 
-Gtk::TreeModel::iterator AudioDevices::GetActivePlaybackDevice() {
+Gtk::TreeModel::iterator AudioDevices::GetActivePlaybackDeviceIter() const {
     return m_active_playback_iter;
 }
 
-Gtk::TreeModel::iterator AudioDevices::GetActiveCaptureDevice() {
+Gtk::TreeModel::iterator AudioDevices::GetActiveCaptureDeviceIter() const {
     return m_active_capture_iter;
 }
 

--- a/src/audio/devices.hpp
+++ b/src/audio/devices.hpp
@@ -13,9 +13,6 @@ class AudioDevices {
 public:
     AudioDevices();
 
-    Glib::RefPtr<Gtk::ListStore> GetPlaybackDeviceModel();
-    Glib::RefPtr<Gtk::ListStore> GetCaptureDeviceModel();
-
     void SetDevices(ma_device_info *pPlayback, ma_uint32 playback_count, ma_device_info *pCapture, ma_uint32 capture_count);
 
     [[nodiscard]] std::optional<ma_device_id> GetPlaybackDeviceIDFromModel(const Gtk::TreeModel::iterator &iter) const;
@@ -24,11 +21,17 @@ public:
     [[nodiscard]] std::optional<ma_device_id> GetDefaultPlayback() const;
     [[nodiscard]] std::optional<ma_device_id> GetDefaultCapture() const;
 
-    void SetActivePlaybackDevice(const Gtk::TreeModel::iterator &iter);
-    void SetActiveCaptureDevice(const Gtk::TreeModel::iterator &iter);
+    [[nodiscard]] std::optional<ma_device_id> GetActivePlayback() const;
+    [[nodiscard]] std::optional<ma_device_id> GetActiveCapture() const;
 
-    Gtk::TreeModel::iterator GetActivePlaybackDevice();
-    Gtk::TreeModel::iterator GetActiveCaptureDevice();
+    void SetActivePlaybackDeviceIter(const Gtk::TreeModel::iterator &iter);
+    void SetActiveCaptureDeviceIter(const Gtk::TreeModel::iterator &iter);
+
+    [[nodiscard]]  Gtk::TreeModel::iterator GetActivePlaybackDeviceIter() const;
+    [[nodiscard]]  Gtk::TreeModel::iterator GetActiveCaptureDeviceIter() const;
+
+    [[nodiscard]] Glib::RefPtr<Gtk::ListStore> GetPlaybackDeviceModel() const;
+    [[nodiscard]] Glib::RefPtr<Gtk::ListStore> GetCaptureDeviceModel() const;
 
 private:
     class PlaybackColumns : public Gtk::TreeModel::ColumnRecord {

--- a/src/audio/manager.hpp
+++ b/src/audio/manager.hpp
@@ -35,7 +35,19 @@ public:
     void SetOpusBuffer(uint8_t *ptr);
     void FeedMeOpus(uint32_t ssrc, const std::vector<uint8_t> &data);
 
+    void OpenPlaybackDevice(const ma_device_id device_id);
+    void OpenCaptureDevice(const ma_device_id device_id);
+
+    void TryOpenPlaybackDevice(const ma_device_id device_id);
+    void TryOpenCaptureDevice(const ma_device_id device_id);
+
+    void ClosePlaybackDevice();
+    void CloseCaptureDevice();
+
+    void StartPlaybackDevice();
     void StartCaptureDevice();
+
+    void StopPlaybackDevice();
     void StopCaptureDevice();
 
     void SetPlaybackDevice(const Gtk::TreeModel::iterator &iter);
@@ -120,12 +132,10 @@ private:
 
     // playback
     ma_device m_playback_device;
-    ma_device_config m_playback_config;
-    ma_device_id m_playback_id;
+    bool m_playback_device_ready = false;
     // capture
     ma_device m_capture_device;
-    ma_device_config m_capture_config;
-    ma_device_id m_capture_id;
+    bool m_capture_device_ready = false;
 
     ma_context m_context;
 

--- a/src/windows/voicewindow.cpp
+++ b/src/windows/voicewindow.cpp
@@ -190,7 +190,7 @@ VoiceWindow::VoiceWindow(Snowflake channel_id)
     m_playback_combo.set_hexpand(true);
     m_playback_combo.set_halign(Gtk::ALIGN_FILL);
     m_playback_combo.set_model(audio.GetDevices().GetPlaybackDeviceModel());
-    if (const auto iter = audio.GetDevices().GetActivePlaybackDevice()) {
+    if (const auto iter = audio.GetDevices().GetActivePlaybackDeviceIter()) {
         m_playback_combo.set_active(iter);
     }
     m_playback_combo.pack_start(*playback_renderer);
@@ -204,7 +204,7 @@ VoiceWindow::VoiceWindow(Snowflake channel_id)
     m_capture_combo.set_hexpand(true);
     m_capture_combo.set_halign(Gtk::ALIGN_FILL);
     m_capture_combo.set_model(Abaddon::Get().GetAudio().GetDevices().GetCaptureDeviceModel());
-    if (const auto iter = Abaddon::Get().GetAudio().GetDevices().GetActiveCaptureDevice()) {
+    if (const auto iter = Abaddon::Get().GetAudio().GetDevices().GetActiveCaptureDeviceIter()) {
         m_capture_combo.set_active(iter);
     }
     m_capture_combo.pack_start(*capture_renderer);


### PR DESCRIPTION
Hey, here is another PR from me!
Made a few changes to audio handling and cleaned up some of the code. In particular audio devices get started/stopped on demand upon entering voice call. This allows audio backends like PipeWire to suspend sinks when they there isn't anything active connected to them.

`AudioManager`:
* Audio devices get started/stopped on voice connect/disconnect
* Reduce code duplication with `Open/TryOpen` functions
* Don't store device configs and ids

`AudioDevices`:
* Rename `[Get/Set]ActivePlaybackDevice` to `[Get/Set]ActivePlaybackDeviceIter`
* Declare getters as `const` and `[[nodiscard]]`
* Reduce code duplication by using `Get[Playback/Capture]DeviceIDFromModel`
* Add `GetActive[Playback/Capture]`

TODO:
- [x] Start/stop voice audio devices on demand
- [ ] Move notification sounds handling to `AudioManager`
- [ ] Split voice audio into multiple devices per user
- [ ] Add options for persistent audio devices and  split voice audio