### PR TITLE
Docs: Enhance readability and declutter README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ spam filter's wrath:
 
 ### Styling
 
+<details>
+    <summary>Show all styles</summary>
+
 #### CSS selectors
 
 | Selector                       | Description                                                                                       |
@@ -257,6 +260,8 @@ Used in profile popup:
 | `.profile-badges`              | Container for badges                                       |
 | `.profile-badge`               |                                                            |
 
+</details>
+
 ### Settings
 
 Settings are configured (for now) by editing `abaddon.ini`.
@@ -269,6 +274,9 @@ The format is similar to the standard Windows ini format **except**:
 
 This listing is organized by section.
 For example, memory_db would be set by adding `memory_db = true` under the line `[discord]`
+
+<details>
+    <summary>Show all settings</summary>
 
 #### discord
 
@@ -347,3 +355,5 @@ For example, memory_db would be set by adding `memory_db = true` under the line 
 |------------------|------------------------------------------------------------------------------|
 | `ABADDON_NO_FC`  | (Windows only) don't use custom font config                                  |
 | `ABADDON_CONFIG` | change path of configuration file to use. relative to cwd or can be absolute |
+
+</details>


### PR DESCRIPTION
Collapse [Styling](https://github.com/MesaBytes/abaddon/tree/collapsible-sections?tab=readme-ov-file#styling) and [Settings](https://github.com/MesaBytes/abaddon/tree/collapsible-sections?tab=readme-ov-file#settings) sections for a concise README.md, making it easier to find what you need.

Preview changes in [here](https://github.com/MesaBytes/abaddon/tree/collapsible-sections?tab=readme-ov-file#styling).