### PR TITLE
Fix-ups for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ if (APPLE)
     target_link_libraries(abaddon "-framework CoreFoundation")
     target_link_libraries(abaddon "-framework CoreAudio")
     target_link_libraries(abaddon "-framework AudioToolbox")
+    target_link_libraries(abaddon "-framework AudioUnit")
 endif ()
 
 if (ENABLE_VOICE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,9 @@ if (ENABLE_QRCODE_LOGIN)
     target_compile_definitions(abaddon PRIVATE WITH_QRLOGIN)
 endif ()
 
-target_precompile_headers(abaddon PRIVATE <gtkmm.h> src/abaddon.hpp src/util.hpp)
+if (NOT (APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+    target_precompile_headers(abaddon PRIVATE <gtkmm.h> src/abaddon.hpp src/util.hpp)
+endif()
 
 if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR
 (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -4,6 +4,10 @@
 #include <fstream>
 #include <string>
 
+#ifdef __APPLE__
+    #include <unistd.h>
+#endif
+
 using namespace std::literals::string_literals;
 
 #if defined(_WIN32)


### PR DESCRIPTION
1. Precompiled headers target is wrong in CMake and breaks the build with GCC:
https://gitlab.kitware.com/cmake/cmake/-/issues/25656
https://gitlab.kitware.com/cmake/cmake/-/issues/25514

2. `<unistd.h>` is missing.

3. `AudioComponent*` stuff is in `AudioUnit` framework, at least on some systems:
https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.8.sdk/System/Library/Frameworks/AudioUnit.framework/Versions/A/Headers/AudioComponent.h