### PR TITLE
platform.cpp: add a missing spdlog include

### DIFF
--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -4,6 +4,8 @@
 #include <fstream>
 #include <string>
 
+#include <spdlog/spdlog.h>
+
 using namespace std::literals::string_literals;
 
 #if defined(_WIN32)


### PR DESCRIPTION
And looks like this is needed, otherwise `spdlog::` is undefined.