### PR TITLE
Optionally use AppIndicator for system tray

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,16 @@ if (Fontconfig_FOUND)
     target_link_libraries(abaddon Fontconfig::Fontconfig)
 endif ()
 
+pkg_check_modules(APPINDICATOR QUIET appindicator3-0.1)
+if (APPINDICATOR_FOUND)
+    message("AppIndicator was found")
+    target_compile_definitions(abaddon PRIVATE WITH_APPINDICATOR)
+    target_include_directories(abaddon PUBLIC ${APPINDICATOR_INCLUDE_DIRS})
+    target_link_libraries(abaddon ${APPINDICATOR_LIBRARIES})
+else ()
+    message("AppIndicator not found. Falling back to GTK StatusIcon")
+endif ()
+
 find_package(spdlog REQUIRED)
 target_link_libraries(abaddon spdlog::spdlog)
 

--- a/src/abaddon.hpp
+++ b/src/abaddon.hpp
@@ -14,6 +14,10 @@
 #include "notifications/notifications.hpp"
 #include "audio/manager.hpp"
 
+#ifdef WITH_APPINDICATOR
+#include <libappindicator/app-indicator.h>
+#endif
+
 #define APP_TITLE "Abaddon"
 
 class AudioManager;
@@ -149,6 +153,7 @@ protected:
     Gtk::Menu *m_user_menu_roles_submenu;
     Gtk::Menu *m_tray_menu;
     Gtk::MenuItem *m_tray_exit;
+    Gtk::MenuItem *m_tray_show;
 
     void on_user_menu_insert_mention();
     void on_user_menu_ban();
@@ -156,10 +161,13 @@ protected:
     void on_user_menu_copy_id();
     void on_user_menu_open_dm();
     void on_user_menu_remove_recipient();
-    void on_tray_click();
-    void on_tray_popup_menu(int button, int activate_time);
-    void on_tray_menu_click();
+    void on_tray_show();
+    void on_tray_exit();
     void on_window_hide();
+#ifndef WITH_APPINDICATOR
+    void on_tray_popup_menu(int button, int activate_time);
+#endif
+
 
 private:
     SettingsManager m_settings;
@@ -182,7 +190,11 @@ private:
     mutable std::mutex m_mutex;
     Glib::RefPtr<Gtk::Application> m_gtk_app;
     Glib::RefPtr<Gtk::CssProvider> m_css_provider;
+#ifdef WITH_APPINDICATOR
+    AppIndicator* m_tray;
+#else
     Glib::RefPtr<Gtk::StatusIcon> m_tray;
+#endif
     std::unique_ptr<MainWindow> m_main_window; // wah wah cant create a gtkstylecontext fuck you
 
     Notifications m_notifications;


### PR DESCRIPTION
Adds extra codepath to use libappindicator to show system tray icon

Benefits:
- Icon will show on wayland panels
- Icon should show even when abaddon is running in a container (although I've not proven this with a test)
- AppIndicator silently switches between itself and GTK StatusIcon depending on what panel is available

Downsides:
- AppIndicator only uses a menu, no direct left-click callback

Other considerations:
- I am completely unable to test this on Windows or Mac. I believe the conditional CMake setup won't break those but I know almost nothing about CMake.
- I've successfully tested on Arch, Debian and Ubuntu. Both with and without libappindicator installed.
- Code consistency. I tried to auto-format to keep it in line, but that only broke it more. Please point out corrections I must make.