### PR TITLE
Improve Packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(abaddon)
 
-set(ABADDON_RESOURCE_DIR "/usr/share/abaddon" CACHE PATH "Fallback directory for resources on Linux")
+set(ABADDON_RESOURCE_DIR "${CMAKE_INSTALL_PREFIX}/share/abaddon" CACHE PATH "Fallback directory for resources on Linux")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
@@ -220,3 +220,9 @@ set(ABADDON_COMPILER_DEFS "" CACHE STRING "Additional compiler definitions")
 foreach (COMPILER_DEF IN LISTS ABADDON_COMPILER_DEFS)
     target_compile_definitions(abaddon PRIVATE "${COMPILER_DEF}")
 endforeach ()
+
+install(TARGETS abaddon RUNTIME)
+install(DIRECTORY res/css DESTINATION ${ABADDON_RESOURCE_DIR})
+install(DIRECTORY res/fonts DESTINATION ${ABADDON_RESOURCE_DIR})
+install(DIRECTORY res/res DESTINATION ${ABADDON_RESOURCE_DIR})
+

--- a/ci/make-msys2-release.sh
+++ b/ci/make-msys2-release.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+BUILDDIR=./abaddon-0.2.1
+
+if [ ! -d ${BUILDDIR} ]; then
+    echo "Directory '${BUILDDIR}' does not exist."
+    exit
+fi
+
+rm -r ${BUILDDIR}/include/
+rm -r ${BUILDDIR}/lib/
+
+mkdir -p ${BUILDDIR}/etc/ssl/certs/
+cp /mingw64/etc/ssl/certs/ca-bundle.crt ${BUILDDIR}/etc/ssl/certs/
+
+mkdir -p ${BUILDDIR}/lib/
+cp -r /mingw64/lib/gdk-pixbuf-2.0 ${BUILDDIR}/lib/
+
+mkdir -p ${BUILDDIR}/share/glib-2.0/schemas/
+cp /mingw64/share/glib-2.0/schemas/gschemas.compiled ${BUILDDIR}/share/glib-2.0/schemas/
+
+cat "../ci/msys-deps.txt" | sed 's/\r$//' | xargs -I % cp /mingw64% ${BUILDDIR}/bin/ || :
+cp /usr/bin/msys-ffi-8.dll ${BUILDDIR}/bin/libffi-8.dll
+
+mkdir -p ${BUILDDIR}/share/themes/
+wget -nc https://github.com/rtlewis1/GTK/archive/refs/heads/Material-Black-Colors-Desktop.zip
+unzip -q -o Material-Black-Colors-Desktop.zip 'GTK-Material-Black-Colors-Desktop/Material-Black-Cherry/**/*'
+mv ./GTK-Material-Black-Colors-Desktop/Material-Black-Cherry ${BUILDDIR}/share/themes/
+cp -r ../ci/tree/. ${BUILDDIR}/
+
+mkdir -p ${BUILDDIR}/share/icons/Adwaita/{16x16,24x24,32x32,48x48,64x64,96x96,scalable}/{actions,devices,status,places}
+cp ../ci/gtk-for-windows/gtk-nsis-pack/share/icons/Adwaita/index.theme ${BUILDDIR}/share/icons/Adwaita/
+for res in 16x16 24x24 32x32 48x48 64x64 96x96; do \
+	cat "../ci/used-icons.txt" | sed 's/\r$//' | \
+	xargs -I % cp ../ci/gtk-for-windows/gtk-nsis-pack/share/icons/Adwaita/${res}/%.symbolic.png \
+	${BUILDDIR}/share/icons/Adwaita/${res}/%.symbolic.png || : \
+; done
+cat "../ci/used-icons.txt" | sed 's/\r$//' | \
+	xargs -I % cp ../ci/gtk-for-windows/gtk-nsis-pack/share/icons/Adwaita/scalable/%.svg \
+	${BUILDDIR}/share/icons/Adwaita/scalable/%.svg || :
+cd ${BUILDDIR}/share/icons/Adwaita/
+gtk-update-icon-cache .
+


### PR DESCRIPTION
Adds CMake install targets.
Linux and BSD users can then install with a simple 'make install'.

Windows users can initialize the CMake build directory with:
-DCMAKE_INSTALL_PREFIX=${PWD}/abaddon-0.2.1 -DABADDON_RESOURCE_DIR=${PWD}/abaddon-0.2.1/bin

and do a 'ninja install' for a more automated install.

Lastly, Windows users can execute the 'ci/make-msys2-release.sh' script that will add all necessary files to the install directory so that users can run abaddon outside of msys2.

Fixes #290
Take note that this was only tested for Windows, Linux, and OpenBSD.
I am unable to test on macOS or able to create a macOS build script for creating an abaddon.app