### PR TITLE
Add missing WITH_RNNOISE gate (Fixes #334)

### DIFF
--- a/src/windows/voice/voicewindow.cpp
+++ b/src/windows/voice/voicewindow.cpp
@@ -115,10 +115,12 @@ VoiceWindow::VoiceWindow(Snowflake channel_id)
         UpdateVADParamValue();
     });
 
+#ifdef WITH_RNNOISE
     m_noise_suppression.set_active(audio.GetSuppressNoise());
     m_noise_suppression.signal_toggled().connect([this]() {
         Abaddon::Get().GetAudio().SetSuppressNoise(m_noise_suppression.get_active());
     });
+#endif
 
     m_mix_mono.set_active(audio.GetMixMono());
     m_mix_mono.signal_toggled().connect([this]() {


### PR DESCRIPTION
Fix a small bug that I encountered while building abaddon with `-DENABLE_RNNOISE=OFF`.  
Fixes #334 .