### PR TITLE
Include recommended glibc header instead of internal one

### DIFF
--- a/src/util.hpp
+++ b/src/util.hpp
@@ -11,7 +11,7 @@
 #include <regex>
 #include <mutex>
 #include <condition_variable>
-#include <glibconfig.h>
+#include <glib.h>
 #include <optional>
 #include <type_traits>
 


### PR DESCRIPTION
Starting with glibc-2.32, you should only include top level headers, otherwise it will cause an error.
https://docs.gtk.org/glib/compiling.html
> The recommended way of using GLib has always been to only include the toplevel headers glib.h, glib-object.h, gio.h. Starting with 2.32, GLib enforces this by generating an error when individual headers are directly included.

It seems that this issue hasn't occurred in CI because of PCH.

```
$ cmake -B build -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
$ cmake --build build
[  2%] Built target keychain
[  4%] Built target qrcodegen
[  5%] Building CXX object CMakeFiles/abaddon.dir/src/platform.cpp.o
In file included from /usr/lib64/glib-2.0/include/glibconfig.h:9,
                 from /home/me/abaddon/src/util.hpp:14,
                 from /home/me/abaddon/src/platform.cpp:11:
/usr/include/glib-2.0/glib/gmacros.h:35:2: error: #error "Only <glib.h> can be included directly."
   35 | #error "Only <glib.h> can be included directly."
      |  ^~~~~
gmake[2]: *** [CMakeFiles/abaddon.dir/build.make:1042: CMakeFiles/abaddon.dir/src/platform.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:103: CMakeFiles/abaddon.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

Downstream bug: https://bugs.gentoo.org/942616