### PR TITLE
Improve Void Linux dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,7 @@ the result of fundamental issues with Discord's thread implementation.
       ```
     * On Void Linux:
       ```Shell
-      $ # Install core dependencies
-      $ sudo xbps-install cmake make meson pkg-config gcc libcurl libcurl-devel libsecret libsecret-devel gtkmm gtkmm-devel sqlite sqlite-devel openssl openssl-devel libhandy1 libhandy1-devel opus opus-devel libsodium libsodium-devel spdlog libspdlog
-      $ # Clone and install nlohmann json:
-      $ git clone https://github.com/nlohmann/json && cd json
-      $ mkdir build
-      $ meson build
-      $ cd build
-      $ sudo meson install
-      $ cd ../..
+      $ sudo xbps-install cmake make json-c++ pkg-config gcc libcurl libcurl-devel libsecret libsecret-devel gtkmm gtkmm-devel sqlite sqlite-devel openssl openssl-devel libhandy1 libhandy1-devel opus opus-devel libsodium libsodium-devel spdlog libspdlog
       ```
     * On Fedora Linux:
       ```Shell


### PR DESCRIPTION
Previous instructions assumed the nholmann JSON library isn't included in Void's package manager. It is included under the name json-c++. Eliminated the manual build step and included the json-c++ package.